### PR TITLE
Decoupled references tweaks

### DIFF
--- a/app/assets/sass/components/_status-indicator.scss
+++ b/app/assets/sass/components/_status-indicator.scss
@@ -1,55 +1,45 @@
 .app-status-indicator {
   align-items: center;
-  border: govuk-spacing(1) solid;
   border-radius: 100%;
   display: inline-flex;
-  height: govuk-spacing(1);
+  height: govuk-spacing(2);
   justify-content: center;
-  width: govuk-spacing(1);
+  width: govuk-spacing(2);
   margin-right: govuk-spacing(1);
 }
 
 .app-status-indicator--grey {
-  background-color: govuk-shade(govuk-colour("dark-grey"), 30);
-  border-color: govuk-tint(govuk-colour("dark-grey"), 90);
+  background-color: govuk-colour("mid-grey");
 }
 
 .app-status-indicator--purple {
-  background-color: govuk-shade(govuk-colour("purple"), 20);
-  border-color: govuk-tint(govuk-colour("purple"), 80);
+  background-color: govuk-colour("purple");
 }
 
 .app-status-indicator--turquoise {
-  background-color: govuk-shade(govuk-colour("turquoise"), 60);
-  border-color: govuk-tint(govuk-colour("turquoise"), 70);
+  background-color: govuk-colour("turquoise");
 }
 
 .app-status-indicator--blue {
-  background-color: govuk-shade(govuk-colour("blue"), 30);
-  border-color: govuk-tint(govuk-colour("blue"), 80);
+  background-color: govuk-colour("blue");
 }
 
 .app-status-indicator--yellow {
-  background-color: govuk-shade(govuk-colour("yellow"), 65);
-  border-color: govuk-tint(govuk-colour("yellow"), 75);
+  background-color: govuk-colour("yellow");
 }
 
 .app-status-indicator--orange {
-  background-color: govuk-shade(govuk-colour("orange"), 55);
-  border-color: govuk-tint(govuk-colour("orange"), 70);
+  background-color: govuk-colour("orange");
 }
 
 .app-status-indicator--red {
-  background-color: govuk-shade(govuk-colour("red"), 30);
-  border-color: govuk-tint(govuk-colour("red"), 80);
+  background-color: govuk-colour("red");
 }
 
 .app-status-indicator--pink {
-  background-color: govuk-shade(govuk-colour("pink"), 40);
-  border-color: govuk-tint(govuk-colour("pink"), 80);
+  background-color: govuk-colour("pink");
 }
 
 .app-status-indicator--green {
-  background-color: govuk-shade(govuk-colour("green"), 20);
-  border-color: govuk-tint(govuk-colour("green"), 80);
+  background-color: govuk-colour("green");
 }

--- a/app/data/dummy-application.js
+++ b/app/data/dummy-application.js
@@ -77,7 +77,7 @@ module.exports = {
       relationship: 'Faith leader who I have known since January 2018',
       email: 'jane.doe@example.com',
       type: 'Character',
-      status: 'Cancelled',
+      status: 'Request cancelled',
       nudges: 0,
       log: [{
         note: 'Request sent',

--- a/app/filters.js
+++ b/app/filters.js
@@ -189,7 +189,7 @@ module.exports = (env) => {
         return `${prefix}--yellow`
       case 'Reference given':
         return `${prefix}--green`
-      case 'Cancelled':
+      case 'Request cancelled':
         return `${prefix}--orange`
       case 'Reference declined':
       case 'Request failed':

--- a/app/views/_includes/item/reference.njk
+++ b/app/views/_includes/item/reference.njk
@@ -10,6 +10,12 @@
 {% set contextHtml %}
   {% if status == "Awaiting response" %}
     <p class="govuk-body govuk-!-margin-top-2">We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.</p>
+  {% elif status == "Reference overdue" %}
+    <p class="govuk-body govuk-!-margin-top-2">Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam. You can also add more referees to increase your changes of getting a reference quickly.</p>
+  {% elif status == "Request cancelled" %}
+    <p class="govuk-body govuk-!-margin-top-2">Training providers will not see any information about this reference request.</p>
+  {% elif status == "Request failed" %}
+    <p class="govuk-body govuk-!-margin-top-2">The reference request never reached your referee.</p>
   {% elif status == "Deactivated" %}
     <p class="govuk-body govuk-!-margin-top-2">This reference will not be sent to any provider.</p>
   {% endif %}

--- a/app/views/_includes/item/reference.njk
+++ b/app/views/_includes/item/reference.njk
@@ -106,7 +106,7 @@
     actions: {
       items: [{
         href: applicationPath + "/references/" + item.id + "/action/nudge?referrer=" + referrer,
-        text: "Send a reminder to this referee"
+        text: "Send them a reminder"
       }]
     } if canNudgeReferee
   } if item.log and showReferenceRequestLog]

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -38,7 +38,7 @@
           text: "Cancel request"
         } if canCancelRequest, {
           href: applicationPath + "/references/" + item.id + "/action/request?referrer=" + referrer,
-          text: "Re-request reference" if (item.status == "Request cancelled" or item.status == "Request failed") else "Request reference"
+          text: "Re-request reference" if (item.status == "Request cancelled" or item.status == "Request failed") else "Send request"
         } if canMakeRequest, {
           href: applicationPath + "/references/" + item.id + "/action/deactivate?referrer=" + referrer,
           text: "Deactivate reference"

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -14,7 +14,7 @@
     {% set canAmendReferee = item.status == "Not requested yet" %}
     {% set canAmendEmailAddress = item.status == "Request failed" %}
     {% set canCancelRequest = (item.status == "Awaiting response") or (item.status == "Reference overdue") %}
-    {% set canMakeRequest = ((item.status == "Not requested yet") or (item.status == "Cancelled") or (item.status == "Request failed")) and readyReferences.length < 2 %}
+    {% set canMakeRequest = ((item.status == "Not requested yet") or (item.status == "Request cancelled") or (item.status == "Request failed")) and readyReferences.length < 2 %}
     {% set canNudgeReferee = ((item.status == "Awaiting response") or (item.status == "Reference overdue")) and item.nudges < 1 %}
 
     {# Deactivating references is an idea we can return to later #}
@@ -38,7 +38,7 @@
           text: "Cancel request"
         } if canCancelRequest, {
           href: applicationPath + "/references/" + item.id + "/action/request?referrer=" + referrer,
-          text: "Re-request reference" if (item.status == "Cancelled" or item.status == "Request failed") else "Request reference"
+          text: "Re-request reference" if (item.status == "Request cancelled" or item.status == "Request failed") else "Request reference"
         } if canMakeRequest, {
           href: applicationPath + "/references/" + item.id + "/action/deactivate?referrer=" + referrer,
           text: "Deactivate reference"

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -113,29 +113,29 @@
   {% set references = applicationValue(["references"]) | toArray %}
   {% set readyReferences = references | selectattr("ready") | reverse %}
 
-  {% if readyReferences | length >= 2 %}
-    {% set referencesItemText = "Review your references" %}
-    {% set referencesTagText = tagText %}
-    {% set referencesTagClass = tagClass %}
-  {% else %}
-    <p class="govuk-body govuk-!-margin-bottom-2">You need 2 references before you can submit your application.</p>
-    <p class="govuk-body">It takes 8 days to get a reference on average.</p>
-    {% if references | length %}
+  {% if references | length %}
+    {% if readyReferences | length >= 2 %}
+      {% set referencesItemText = "Review your references" %}
+      {% set referencesTagText = tagText %}
+      {% set referencesTagClass = tagClass %}
+    {% else %}
       {% set referencesItemText = "Manage your references" %}
       {% set referencesTagText = inprogressTagText %}
       {% set referencesTagClass = inprogressTagClass %}
-      {% set referencesContent %}
-        <ul class="govuk-list">
-        {% for reference in references %}
-          <li class="govuk-body-s"><span class="app-status-indicator {{ reference.status | statusClass("app-status-indicator") }}"></span> <b>{{ reference.name }}</b>: {{ reference.status }}</li>
-        {% endfor %}
-        </ul>
-      {% endset %}
-    {% else %}
-      {% set referencesItemText = "Add your references" %}
-      {% set referencesTagText = incompleteTagText %}
-      {% set referencesTagClass = incompleteTagClass %}
     {% endif %}
+    {% set referencesContent %}
+      <ul class="govuk-list">
+      {% for reference in references %}
+        <li class="govuk-body-s"><span class="app-status-indicator {{ reference.status | statusClass("app-status-indicator") }}"></span> <b>{{ reference.name }}</b>: {{ reference.status }}</li>
+      {% endfor %}
+      </ul>
+    {% endset %}
+  {% else %}
+    <p class="govuk-body govuk-!-margin-bottom-2">You need 2 references before you can submit your application.</p>
+    <p class="govuk-body">It takes 8 days to get a reference on average.</p>
+    {% set referencesItemText = "Add your references" %}
+    {% set referencesTagText = incompleteTagText %}
+    {% set referencesTagClass = incompleteTagClass %}
   {% endif %}
 
   {{ appTaskList({

--- a/app/views/application/references/action.njk
+++ b/app/views/application/references/action.njk
@@ -13,7 +13,7 @@
 {% elif action == "cancel" %}
   {% set title = "Are you sure you want to cancel this reference request?" %}
   {% set buttonText = "Yes I’m sure - cancel this reference request" %}
-  {% set status = "Cancelled" %}
+  {% set status = "Request cancelled" %}
   {% set destructive = true %}
 {% elif action == "nudge" %}
   {% set title = "Would you like to send a reminder to this referee?" %}

--- a/app/views/application/references/candidate.njk
+++ b/app/views/application/references/candidate.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
-{% set title = "Your name" %}
-{% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/name/" %}
+{% set title = "Give your name so the referee knows who you are" %}
+{% set formaction = "/application/" + applicationId + "/references/" + id + "/request/" %}
 
 {% block pageNavigation %}
   {% if referrer %}
@@ -10,7 +10,7 @@
     }) }}
   {% else %}
     {{ govukBackLink({
-      href: "/application/" + applicationId + "/references/" + id + "/start/"
+      href: "/application/" + applicationId + "/references/" + id + "/relationship/"
     }) }}
   {% endif %}
 {% endblock %}

--- a/app/views/application/references/email.njk
+++ b/app/views/application/references/email.njk
@@ -3,7 +3,7 @@
 {% set referee = applicationValue(["references", id]) %}
 {% set parent = referee.name %}
 {% set title = "Referee email address" %}
-{% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/type/" %}
+{% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/relationship/" %}
 
 {% block pageNavigation %}
   {% if referrer %}

--- a/app/views/application/references/name.njk
+++ b/app/views/application/references/name.njk
@@ -10,7 +10,7 @@
     }) }}
   {% else %}
     {{ govukBackLink({
-      href: "/application/" + applicationId + "/references/" + id + "/start/"
+      href: "/application/" + applicationId + "/references/" + id + "/type/"
     }) }}
   {% endif %}
 {% endblock %}

--- a/app/views/application/references/relationship.njk
+++ b/app/views/application/references/relationship.njk
@@ -3,7 +3,11 @@
 {% set referee = applicationValue(["references", id]) %}
 {% set parent = referee.name %}
 {% set title = "How do you know this referee and how long have you known them?" %}
-{% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/request/" %}
+{% if applicationValue(["candidate", "given-name"]) %}
+  {% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/request/" %}
+{% else %}
+  {% set formaction = "/application/" + applicationId + "/references/" + id + "/candidate/" %}
+{% endif %}
 
 {% block pageNavigation %}
   {% if referrer %}

--- a/app/views/application/references/start.njk
+++ b/app/views/application/references/start.njk
@@ -23,6 +23,6 @@
 
   {{ govukButton({
     text: "Continue",
-    href: "/application/" + applicationId + "/references/" + id + "/name/"
+    href: "/application/" + applicationId + "/references/" + id + "/type/"
   }) }}
 {% endblock %}

--- a/app/views/application/references/start.njk
+++ b/app/views/application/references/start.njk
@@ -1,11 +1,6 @@
 {% extends "_content.njk" %}
 
 {% set title = "Choose your referees" %}
-{% if applicationValue(["candidate", "given-name"]) %}
-  {% set buttonLink = "/application/" + applicationId + "/references/" + id + "/name/" %}
-{% else %}
-  {% set buttonLink = "/application/" + applicationId + "/references/" + id + "/candidate/" %}
-{% endif %}
 
 {% block pageNavigation %}
   {% if referrer %}
@@ -28,6 +23,6 @@
 
   {{ govukButton({
     text: "Continue",
-    href: buttonLink
+    href: "/application/" + applicationId + "/references/" + id + "/name/"
   }) }}
 {% endblock %}

--- a/app/views/application/references/type.njk
+++ b/app/views/application/references/type.njk
@@ -2,8 +2,8 @@
 
 {% set referee = applicationValue(["references", id]) %}
 {% set parent = referee.name %}
-{% set title = "What kind of reference can this referee give?" %}
-{% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/relationship/" %}
+{% set title = "What kind of referee do you want to add?" %}
+{% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/name/" %}
 
 {% block pageNavigation %}
   {% if referrer %}
@@ -12,7 +12,7 @@
     }) }}
   {% else %}
     {{ govukBackLink({
-      href: "/application/" + applicationId + "/references/" + id + "/email/"
+      href: "/application/" + applicationId + "/references/" + id + "/start/"
     }) }}
   {% endif %}
 {% endblock %}
@@ -43,10 +43,7 @@
     }, {
       text: "Character",
       hint: {
-        html: "
-          <p class=\"govuk-hint\">For example: a mentor, or someone you know from volunteering.</p>
-          <p class=\"govuk-hint\">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
-        "
+        text: "For example: a mentor, or someone you know from volunteering."
       }
     }]
   } | decorateApplicationAttributes(["references", id, "type"])) }}

--- a/app/views/application/references/type.njk
+++ b/app/views/application/references/type.njk
@@ -26,13 +26,27 @@
       }
     },
     items: [{
-      text: "Academic"
+      text: "Academic",
+      hint: {
+        text: "For example: a university tutor."
+      }
     }, {
-      text: "Professional"
+      text: "Professional",
+      hint: {
+        text: "For example: a manager."
+      }
+    }, {
+      text: "School-based",
+      hint: {
+        text: "For example: a colleague from a school where you did experience."
+      }
     }, {
       text: "Character",
       hint: {
-        text: "Training providers will only accept a character reference if there’s also an academic or professional reference."
+        html: "
+          <p class=\"govuk-hint\">For example: a mentor, or someone you know from volunteering.</p>
+          <p class=\"govuk-hint\">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
+        "
       }
     }]
   } | decorateApplicationAttributes(["references", id, "type"])) }}


### PR DESCRIPTION
* Persist individual reference statuses on application
* Update design of status indicator
* Add and update content supporting reference states
* Update actions on reference summary card
* Reinstate school based reference and examples
* Move candidate name to end of referee flow
* Move referee type to beginning of referee flow
