### PR TITLE
Decoupled references (post UR playback)

### DIFF
--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -14,6 +14,7 @@
     {# Available actions #}
     {% set canAmendReferee = item.status == "Not requested yet" %}
     {% set canAmendEmailAddress = item.status == "Request failed" %}
+    {% set canDelete = (item.status == "Not requested yet") or (item.status == "Request cancelled") or (item.status == "Reference declined") or (item.status == "Request failed") %}
     {% set canCancelRequest = (item.status == "Awaiting response") or (item.status == "Reference overdue") %}
     {% set canMakeRequest = ((item.status == "Not requested yet") or (item.status == "Request cancelled") or (item.status == "Request failed")) and readyReferences.length < 2 %}
     {% set canNudgeReferee = ((item.status == "Awaiting response") or (item.status == "Reference overdue")) and item.nudges < 1 %}
@@ -33,8 +34,8 @@
       actions: {
         items: [{
           href: applicationPath + "/references/" + item.id + "/action/delete?referrer=" + referrer,
-          text: "Delete referee"
-        } if canAmendReferee, {
+          text: "Delete referee" if item.status == "Not requested yet" else "Delete request"
+        } if canDelete, {
           href: applicationPath + "/references/" + item.id + "/action/cancel?referrer=" + referrer,
           text: "Cancel request"
         } if canCancelRequest, {

--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -133,6 +133,9 @@
       }, {
         href: "/application/" + applicationId + "/emails/reference-given",
         text: "A reference has been given"
+      }, {
+        href: "/application/" + applicationId + "/emails/reference-2-given",
+        text: "Both references have been given"
       }]
     }] if references.length,
     meta: {

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -126,7 +126,9 @@
     {% set referencesTagClass = tagClass %}
     {% set showReferencesContent = true %}
   {% else %}
-    <p class="govuk-body govuk-!-margin-bottom-2">You need 2 references before you can submit your application.</p>
+    <!--p class="govuk-body govuk-!-margin-bottom-2">You need to receive 2 references before sending your application to training providers.</p-->
+    <p class="govuk-body govuk-!-margin-bottom-2">You have to get 2 references back before you can send your application to training providers.</p>
+
     <p class="govuk-body">It takes 8 days to get a reference on average.</p>
     {% if references | length > 0 %}
       {% set referencesItemText = "Manage your references" %}
@@ -301,9 +303,10 @@
       href: applicationPath + "/review?closed=true"
     }) }}
   {% else %}
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Check and submit</h2>
+    <h2 class="govuk-heading-m govuk-!-font-size-27">Review and send</h2>
+    <p>Review and send your application to your training {{ "providers" if (applicationValue(["choices"]) | length > 1) else "provider" }}.</p>
     {{ govukButton({
-      text: "Check and submit your application",
+      text: "Review your application",
       href: applicationPath + "/review"
     }) }}
   {% endif %}

--- a/app/views/application/references/action.njk
+++ b/app/views/application/references/action.njk
@@ -3,8 +3,9 @@
 {% set referee = applicationValue(["references", id]) %}
 {% set parent = referee.name %}
 {% if action == "delete" %}
-  {% set title = "Are you sure you want to delete this referee?" %}
-  {% set buttonText = "Yes I’m sure - delete this referee" %}
+  {% set type = "referee" if item.status == "Not requested yet" else "request" %}
+  {% set title = "Are you sure you want to delete this " + type + "?" %}
+  {% set buttonText = "Yes I’m sure - delete this " + type %}
   {% set destructive = true %}
 {% elif action == "request" %}
   {% set title = "Are you ready to send a reference request?" %}

--- a/app/views/application/references/candidate.njk
+++ b/app/views/application/references/candidate.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "What is your name?" %}
+{% set title = "Tell the referee your name" %}
 {% set formaction = "/application/" + applicationId + "/references/" + id + "/send-request/" %}
 
 {% block pageNavigation %}

--- a/app/views/application/references/candidate.njk
+++ b/app/views/application/references/candidate.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set title = "What is your name?" %}
-{% set formaction = "/application/" + applicationId + "/references/" + id + "/request/" %}
+{% set formaction = "/application/" + applicationId + "/references/" + id + "/send-request/" %}
 
 {% block pageNavigation %}
   {% if referrer %}
@@ -10,13 +10,13 @@
     }) }}
   {% else %}
     {{ govukBackLink({
-      href: "/application/" + applicationId + "/references/" + id + "/relationship/"
+      href: "/application/" + applicationId + "/references/" + id + "/request/"
     }) }}
   {% endif %}
 {% endblock %}
 
 {% block primary %}
-{{ govukInput({
+  {{ govukInput({
     label: {
       text: "First name",
       classes: "govuk-label--m"

--- a/app/views/application/references/relationship.njk
+++ b/app/views/application/references/relationship.njk
@@ -3,11 +3,7 @@
 {% set referee = applicationValue(["references", id]) %}
 {% set parent = referee.name %}
 {% set title = "How do you know this referee and how long have you known them?" %}
-{% if applicationValue(["candidate", "given-name"]) %}
-  {% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/request/" %}
-{% else %}
-  {% set formaction = "/application/" + applicationId + "/references/" + id + "/candidate/" %}
-{% endif %}
+{% set formaction = referrer or "/application/" + applicationId + "/references/" + id + "/request/" %}
 
 {% block pageNavigation %}
   {% if referrer %}

--- a/app/views/application/references/review.njk
+++ b/app/views/application/references/review.njk
@@ -32,6 +32,7 @@
   {% if readyReferences | length < 2 %}
     <div class="govuk-inset-text govuk-!-margin-top-0">
       <p class="govuk-body">You need 2 references before you can submit your application.</p>
+      <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
       {{ govukButton({
         text: "Add another referee",
         href: "/application/" + applicationId + "/references/add?referrer=" + referrer

--- a/app/views/application/submit.njk
+++ b/app/views/application/submit.njk
@@ -2,7 +2,8 @@
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set status = applicationValue(["status"]) %}
-{% set title = "Submit application" %}
+{% set providerText = "providers" if (applicationValue(["choices"]) | length > 1) else "provider" %}
+{% set title = "Send application to training " + providerText %}
 {% set formaction = "/send-email/" + applicationId + "/application-submitted" %}
 
 {% block pageNavigation %}
@@ -23,9 +24,9 @@
     html: dbsCheckHtml
   }) }}
 
-  <p class="govuk-body">By submitting, I confirm that the information given is true, complete and accurate.</p>
+  <p class="govuk-body">By sending this application to {{ providerText }}, I confirm that the information given is true, complete and accurate.</p>
 
   {{ govukButton({
-    text: "Submit application"
+    text: "Send application"
   }) }}
 {% endblock %}

--- a/app/views/emails/reference-2-given.njk
+++ b/app/views/emails/reference-2-given.njk
@@ -1,0 +1,13 @@
+{% extends "_email.njk" %}
+{% set references = applicationValue(["references"]) | toArray %}
+{% set referee = references[0] %}
+
+{% set title = "You have a reference from " + referee.name %}
+
+{% block content %}
+  <h1 class="govuk-heading-m">{{ title }}</h1>
+  <p class="govuk-body">You’ve got 2 references back now.</p>
+  <p class="govuk-body">When you’re ready, you can send your application to training providers.</p>
+  <p class="govuk-body">Sign in to continue your application:</p>
+  <p class="govuk-body"><a href="/application/{{ applicationId }}">https://{{ serviceSlug }}.service.gov.uk/<wbr>confirm_authentication?token=FPoZNtUaGsqPevCd5GV&amp;<wbr>u=elM2TVdzZnBzRUJ1LzdSMmlOYW10QT09LS1MLy8xcVdSUmlpVVNkdzNiTG11bTdRPT0%3D</a></p>
+{% endblock %}

--- a/app/views/emails/reference-given.njk
+++ b/app/views/emails/reference-given.njk
@@ -6,6 +6,8 @@
 
 {% block content %}
   <h1 class="govuk-heading-m">{{ title }}</h1>
+  <p class="govuk-body">You need to get another reference back before you can send your application to training providers.</p>
+  <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
   <p class="govuk-body">Manage your references:</p>
   <p class="govuk-body"><a href="/application/{{ applicationId }}/references/mock/given">https://{{ serviceSlug }}.service.gov.uk/<wbr>candidate/<wbr>confirm_authentication?token=FPoZNtUaGsqPevCd5GV&amp;<wbr>u=elM2TVdzZnBzRUJ1LzdSMmlOYW10QT09LS1MLy8xcVdSUmlpVVNkdzNiTG11bTdRPT0%3D</a></p>
 {% endblock %}


### PR DESCRIPTION
* Ask for candidate name (if not yet given) at point candidate makes reference request
* Add ability to delete cancelled/declined/failed reference requests
* Review content around needing 2 references to have been given before you can submit
* Change language from ‘submit’ to more along the lines of ‘sending to training providers’
* Update emails when 1 and 2 references given