### PR TITLE
Retry reference request

### DIFF
--- a/app/routes/application/references.js
+++ b/app/routes/application/references.js
@@ -127,6 +127,15 @@ module.exports = router => {
         req.flash('success', `Reminder sent to ${applicationData.references[id].name}`)
       }
 
+      if (action === 'retry') {
+        applicationData.references[id].log.push({
+          note: `Request sent to ${applicationData.references[id].email}`,
+          date: now.toISOString()
+        })
+
+        req.flash('success', `Reference request sent to ${applicationData.references[id].email}`)
+      }
+
       res.redirect(referrer)
     }
   })

--- a/app/views/_includes/item/reference.njk
+++ b/app/views/_includes/item/reference.njk
@@ -63,7 +63,7 @@
         text: "Change",
         visuallyHiddenText: "email address"
       }]
-    } if canAmendReferee or canAmendEmailAddress
+    } if canAmendReferee
   }, {
     key: {
       text: "Reference type"

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -16,7 +16,8 @@
     {% set canAmendEmailAddress = item.status == "Request failed" %}
     {% set canDelete = (item.status == "Not requested yet") or (item.status == "Request cancelled") or (item.status == "Reference declined") or (item.status == "Request failed") %}
     {% set canCancelRequest = (item.status == "Awaiting response") or (item.status == "Reference overdue") %}
-    {% set canMakeRequest = ((item.status == "Not requested yet") or (item.status == "Request cancelled") or (item.status == "Request failed")) and readyReferences.length < 2 %}
+    {% set canMakeRequest = ((item.status == "Not requested yet") or (item.status == "Request cancelled")) and readyReferences.length < 2 %}
+    {% set canRetryRequest = (item.status == "Request failed") and readyReferences.length < 2 %}
     {% set canNudgeReferee = ((item.status == "Awaiting response") or (item.status == "Reference overdue")) and item.nudges < 1 %}
 
     {# Deactivating references is an idea we can return to later #}
@@ -33,15 +34,18 @@
       titleText: item.type + " reference from " + item.name,
       actions: {
         items: [{
-          href: applicationPath + "/references/" + item.id + "/action/delete?referrer=" + referrer,
-          text: "Delete referee" if item.status == "Not requested yet" else "Delete request"
-        } if canDelete, {
           href: applicationPath + "/references/" + item.id + "/action/cancel?referrer=" + referrer,
           text: "Cancel request"
         } if canCancelRequest, {
           href: applicationPath + "/references/" + item.id + "/action/request?referrer=" + referrer,
           text: "Send request again" if (item.status == "Request cancelled" or item.status == "Request failed") else "Send request"
         } if canMakeRequest, {
+          href: applicationPath + "/references/" + item.id + "/action/retry?referrer=" + referrer,
+          text: "Retry request"
+        } if canRetryRequest, {
+          href: applicationPath + "/references/" + item.id + "/action/delete?referrer=" + referrer,
+          text: "Delete referee" if item.status == "Not requested yet" else "Delete request"
+        } if canDelete, {
           href: applicationPath + "/references/" + item.id + "/action/deactivate?referrer=" + referrer,
           text: "Deactivate reference"
         } if canDeactivateReference, {

--- a/app/views/application/references/action.njk
+++ b/app/views/application/references/action.njk
@@ -11,6 +11,10 @@
   {% set title = "Are you ready to send a reference request?" %}
   {% set buttonText = "Yes I’m sure - send my reference request" %}
   {% set status = "Awaiting response" %}
+{% elif action == "retry" %}
+  {% set title = "Retry reference request" %}
+  {% set buttonText = "Send reference request" %}
+  {% set status = "Awaiting response" %}
 {% elif action == "cancel" %}
   {% set title = "Are you sure you want to cancel this reference request?" %}
   {% set buttonText = "Yes I’m sure - cancel this reference request" %}
@@ -38,6 +42,16 @@
 {% block primary %}
   {% if action == "request" %}
     <p class="govuk-body">We’ll send {{ referee.name }} an email asking them to give you a reference.</p>
+  {% elif action == "retry" %}
+    {{ govukInput({
+      label: {
+        classes: "govuk-label--m",
+        text: "Referee’s email address"
+      },
+      hint: {
+        text: "In most cases, this should be a work address."
+      }
+    } | decorateApplicationAttributes(["references", id, "email"])) }}
   {% elif action == "cancel" %}
     <p class="govuk-body">We’ll tell {{ referee.name }} that they no longer need to give a reference.</p>
   {% elif action == "nudge" %}
@@ -61,5 +75,7 @@
     classes: "govuk-button--warning" if destructive
   }) }}
 
-  <p class="govuk-body"><a href="{{ referrer }}">No - I’ve changed my mind</a></p>
+  {% if action != "retry" %}
+    <p class="govuk-body"><a href="{{ referrer }}">No - I’ve changed my mind</a></p>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
(Addresses https://github.com/DFE-Digital/apply-for-teacher-training/pull/3205)

Remove ‘Change’ link next to email, and instead add a ‘Retry request’ action to the summary card header:

<img width="980" alt="Screenshot 2020-10-22 at 17 23 46" src="https://user-images.githubusercontent.com/813383/96902072-f34f4400-148b-11eb-900e-0e70e2eef320.png">

This takes you to a page where you can resend request, and change email (repopulated with previous address used):

<img width="1005" alt="Screenshot 2020-10-22 at 17 23 59" src="https://user-images.githubusercontent.com/813383/96902077-f64a3480-148b-11eb-884a-69ae5ab47852.png">

Summary card status is changed to ‘Awaiting response’ and event added that says ‘Request sent to [new email address]’:

<img width="975" alt="Screenshot 2020-10-22 at 17 27 09" src="https://user-images.githubusercontent.com/813383/96902080-f6e2cb00-148b-11eb-930f-68f3daa790a0.png">
