### PR TITLE
Content update - references start

### DIFF
--- a/app/views/application/references/start.njk
+++ b/app/views/application/references/start.njk
@@ -20,11 +20,13 @@
   <p class="govuk-body">Referees should not be family members, partners or friends.</p>
   <p class="govuk-body">Choose at least one academic referee if you graduated in the last 5 years or you do not have a grade for your degree yet.</p>
   <p class="govuk-body">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
-  <p class="govuk-body">Contact your referees in advance to check they can submit a reference quickly online.</p>
   <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
-
+  <p class="govuk-body">If you're applying for a School Direct (Salaried) course, one of your references must be from an employer.</p>
+  <h2 class="govuk-heading-m">Contact your referees</h2>
+  <p class="govuk-body">Contact your referees in advance to check that they can submit a reference quickly online.</p>
+  <p class="govuk-body">Check that they will give you a full reference and not just confirm the dates you worked there. Providers need to know about your suitability for teacher training.</p>
   {{ govukButton({
-    text: "Continue",
-    href: "/application/" + applicationId + "/references/" + id + "/type/"
+    text: "Continue"
   }) }}
+
 {% endblock %}

--- a/app/views/application/references/start.njk
+++ b/app/views/application/references/start.njk
@@ -21,12 +21,13 @@
   <p class="govuk-body">Choose at least one academic referee if you graduated in the last 5 years or you do not have a grade for your degree yet.</p>
   <p class="govuk-body">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
   <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
-  <p class="govuk-body">If you're applying for a School Direct (Salaried) course, one of your references must be from an employer.</p>
+  <p class="govuk-body">If you’re applying for a School Direct (Salaried) course, one of your references must be from an employer.</p>
   <h2 class="govuk-heading-m">Contact your referees</h2>
   <p class="govuk-body">Contact your referees in advance to check that they can submit a reference quickly online.</p>
   <p class="govuk-body">Check that they will give you a full reference and not just confirm the dates you worked there. Providers need to know about your suitability for teacher training.</p>
   {{ govukButton({
-    text: "Continue"
+    text: "Continue",
+    href: "/application/" + applicationId + "/references/" + id + "/type/"
   }) }}
 
 {% endblock %}

--- a/app/views/application/references/start.njk
+++ b/app/views/application/references/start.njk
@@ -20,11 +20,11 @@
   <p class="govuk-body">Referees should not be family members, partners or friends.</p>
   <p class="govuk-body">Choose at least one academic referee if you graduated in the last 5 years or you do not have a grade for your degree yet.</p>
   <p class="govuk-body">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
-  <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
   <p class="govuk-body">If you’re applying for a School Direct (Salaried) course, one of your references must be from an employer.</p>
+  <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
   <h2 class="govuk-heading-m">Contact your referees</h2>
   <p class="govuk-body">Contact your referees in advance to check that they can submit a reference quickly online.</p>
-  <p class="govuk-body">Check that they will give you a full reference and not just confirm the dates you worked there. Providers need to know about your suitability for teacher training.</p>
+  <p class="govuk-body">Check that they can give you a full reference and not just confirm the dates you worked there. Providers need to know about your suitability for teaching.</p>
   {{ govukButton({
     text: "Continue",
     href: "/application/" + applicationId + "/references/" + id + "/type/"


### PR DESCRIPTION
Include content on SD Salaried courses.
Content to encourage candidates to ensure employers give full references.

@paulrobertlloyd Can you check the CTA on this page too please? Not sure if I've broken something. 