### PR TITLE
Update Start page to include free NARIC statement

### DIFF
--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -60,14 +60,16 @@
     <li class="govuk-body">grade 4 (C) or above in English and maths GCSEs (or equivalent)</li>
   </ul>
 
-  <h3 class="govuk-heading-s">If you studied overseas</h3>
-  <p class="govuk-body">You can <a href="https://www.naric.org.uk/Qualifications/SOC/Default.aspx">get a statement from the National Recognition Information Centre for the UK (UK NARIC)</a> that shows how your qualifications compare to UK qualifications. Some training providers may ask to see it as part of your application.</p>
-
   <h2 class="govuk-heading-m">Get advice and support</h2>
   <p class="govuk-body">You can <a href="https://getintoteaching.education.gov.uk/">register with Get Into Teaching</a>, the Department for Education’s free support and advice service.</p>
 
   <p class="govuk-body">A specialist adviser will help you prepare your application and advise you on funding options (including loans and tax-free bursaries and scholarships). You can also book school experience and access teaching events.</p>
 
+  <h3 class="govuk-heading-s">If you studied overseas</h3>
+  <p class="govuk-body">You can <a href="https://www.naric.org.uk/Qualifications/SOC/Default.aspx">get a statement from the National Recognition Information Centre for the UK (UK NARIC)</a> that shows how your qualifications compare to UK qualifications. Some training providers may ask to see it as part of your application.</p>
+
+  <p class="govuk-body">You may be able to get a free statement of comparability (this usually costs £49.50 plus VAT). Call Get Into Teaching on Freephone 0800 389 2501.</a>
+    
   <h3 class="govuk-heading-s">If you’re disabled or have a health condition</h3>
   <p class="govuk-body">Email <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> if you need extra support with your application.</p>
 

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -68,7 +68,7 @@
   <h3 class="govuk-heading-s">If you studied overseas</h3>
   <p class="govuk-body">You can <a href="https://www.naric.org.uk/Qualifications/SOC/Default.aspx">get a statement from the National Recognition Information Centre for the UK (UK NARIC)</a> that shows how your qualifications compare to UK qualifications. Some training providers may ask to see it as part of your application.</p>
 
-  <p class="govuk-body">You may be able to get a statement that compares your qualifications for free (this usually costs £49.50 plus VAT). Call Get Into Teaching on Freephone 0800 389 2501.</a>
+  <p class="govuk-body">You can get a statement that compares your qualifications for free (this usually costs £49.50 plus VAT). Call Get Into Teaching on Freephone 0800 389 2501.</a>
 
   <h3 class="govuk-heading-s">If you’re disabled or have a health condition</h3>
   <p class="govuk-body">Email <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> if you need extra support with your application.</p>

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -68,8 +68,8 @@
   <h3 class="govuk-heading-s">If you studied overseas</h3>
   <p class="govuk-body">You can <a href="https://www.naric.org.uk/Qualifications/SOC/Default.aspx">get a statement from the National Recognition Information Centre for the UK (UK NARIC)</a> that shows how your qualifications compare to UK qualifications. Some training providers may ask to see it as part of your application.</p>
 
-  <p class="govuk-body">You may be able to get a free statement of comparability (this usually costs £49.50 plus VAT). Call Get Into Teaching on Freephone 0800 389 2501.</a>
-    
+  <p class="govuk-body">You may be able to get a statement that compares your qualifications for free (this usually costs £49.50 plus VAT). Call Get Into Teaching on Freephone 0800 389 2501.</a>
+
   <h3 class="govuk-heading-s">If you’re disabled or have a health condition</h3>
   <p class="govuk-body">Email <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> if you need extra support with your application.</p>
 


### PR DESCRIPTION
@frankieroberto @paulrobertlloyd - could either or both of you cast your eyes over this additional content for the start page before I request the change with GDS, please?

NARIC statements give people who have qualifications from overseas their comparable UK qualifications/grades. 

We already link to the NARIC website on our start page. We don't tell candidates how much they cost or that they can get free statements through Get Into Teaching.

Include this content and move the 'If you studied overseas content' under the 'Get advice and support' H2

I think moving the content makes it flow better because of where we refer to Get Into Teaching (first referred to under Get advice and support), rather than just tagging it on the end of the current 'If you studied overseas' content.

Current state:

![image](https://user-images.githubusercontent.com/54059249/100636806-075b5080-332a-11eb-86d0-554a5ffce836.png)

Proposed state:

![image](https://user-images.githubusercontent.com/54059249/100636919-2659e280-332a-11eb-8288-81b2b07c8ac3.png)
