### PR TITLE
Change NARIC content in Qualifications

### DIFF
--- a/app/views/application/degree/naric.njk
+++ b/app/views/application/degree/naric.njk
@@ -53,7 +53,7 @@
   {% endset -%}
 
   {% set noConditionalHtml %}
-    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. Register with <a href="https://register.getintoteaching.education.gov.uk/register">Get Into Teaching</a> for help if you need to get one.</p>
+    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling Get Into Teaching on Freephone 0800 389 2501.</p>
   {% endset %}
 
   {{ govukRadios({

--- a/app/views/application/gcse/naric.njk
+++ b/app/views/application/gcse/naric.njk
@@ -48,7 +48,7 @@
   {% endset -%}
 
   {% set noConditionalHtml %}
-    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. Register with <a href="https://register.getintoteaching.education.gov.uk/register">Get Into Teaching</a> for help if you need to get one.</p>
+    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling Get Into Teaching on Freephone 0800 389 2501.</p>
   {% endset %}
 
   {{ govukRadios({


### PR DESCRIPTION
Change the NARIC content once 'No' is selected on the Qualifications/NARIC pages for degree and GCSEs.

This is to highlight to candidates that they can get free NARIC statements from Get Into Teaching. Candidates have to call the freephone number to get the free statements so I have removed the link to register. 