### PR TITLE
Collect multi-line international addresses

### DIFF
--- a/app/data/countries.js
+++ b/app/data/countries.js
@@ -221,9 +221,6 @@ module.exports = [{
   value: 'Dubai',
   text: 'Dubai'
 }, {
-  value: 'East Germany',
-  text: 'East Germany'
-}, {
   value: 'East Timor',
   text: 'East Timor'
 }, {

--- a/app/views/application/contact-details/international-address.njk
+++ b/app/views/application/contact-details/international-address.njk
@@ -9,12 +9,43 @@
 {% endblock %}
 
 {% block primary %}
-  {{ govukTextarea({
+  {{ govukInput({
     label: {
-      text: "Enter your address"
+      html: "Building and street <span class=\"govuk-visually-hidden\">line 1 of 2</span>"
     },
-    autocomplete: "street-address"
-  } | decorateApplicationAttributes(["contact-details", "address", "street-address"])) }}
+    autocomplete: "address-line1"
+  } | decorateApplicationAttributes(["contact-details", "address", "line1"])) }}
+
+  {{ govukInput({
+    label: {
+      html: "<span class=\"govuk-visually-hidden\">Building and street line 2 of 2</span>"
+    },
+    autocomplete: "address-line2"
+  } | decorateApplicationAttributes(["contact-details", "address", "line2"])) }}
+
+  {{ govukInput({
+    label: {
+      html: "City, town or village"
+    },
+    classes: "govuk-!-width-two-thirds",
+    autocomplete: "address-level2"
+  } | decorateApplicationAttributes(["contact-details", "address", "level2"])) }}
+
+  {{ govukInput({
+    label: {
+      html: "Region, state or province"
+    },
+    classes: "govuk-!-width-two-thirds",
+    autocomplete: "address-level1"
+  } | decorateApplicationAttributes(["contact-details", "address", "level1"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "ZIP or postal code"
+    },
+    classes: "govuk-!-width-two-thirds",
+    autocomplete: "postal-code"
+  } | decorateApplicationAttributes(["contact-details", "address", "postal-code"])) }}
 
   {# Explictly mark this as an international address if came to this page via a link rather than by form submission on ‘Where do you live’ page #}
   {{ govukInput({


### PR DESCRIPTION
Will investigate other options such as breaking multiline input from a textarea, but I think still that’s ripe with issues converting to a frame that’s suitable for sending to SRSs.

So, alternatively, we can repurpose the inputs we use for UK addresses, but adjust the input labels to show international alternatives. We could customise labels to specific countries, but not sure how much effort that’s worth given current number of international students.

I think the bigger issue is formatting of addresses when previewed; this is where they tend to differ.

| UK address | International address |
| - | - |
| ![uk-address](https://user-images.githubusercontent.com/813383/101066458-59041500-358e-11eb-9f0d-bfe5b1014d38.png) | ![international-address](https://user-images.githubusercontent.com/813383/101066452-573a5180-358e-11eb-8fa3-c538b579f63c.png) |