### PR TITLE
Add additional application states to prototype

### DIFF
--- a/app/data/application-single-choice.js
+++ b/app/data/application-single-choice.js
@@ -1,0 +1,14 @@
+// Copies dummy application and tweaks some fields
+const application = JSON.parse(JSON.stringify(require('./application')))
+
+// No completed sections yet
+module.exports = {
+  status: 'started',
+  welcomeFlow: false,
+  apply2: false,
+  account: {
+    email: 'janina.doe@example.com'
+  },
+  choices: {'ABCDE': application.choices['ABCDE']},
+  references: []
+}

--- a/app/data/application.js
+++ b/app/data/application.js
@@ -2,6 +2,7 @@ module.exports = {
   status: 'started',
   welcomeFlow: false,
   apply2: false,
+  ended_without_success: false,
   completed: {
     'personal-details': ['true'],
     'contact-details': ['true'],

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,12 +1,14 @@
 const application = require('./application')
 const applicationApplyAgain = require('./application-apply-again')
 const applicationWithChoices = require('./application-with-choices')
+const applicationWithSingleChoice = require('./application-single-choice')
 
 module.exports = {
   applications: {
     12345: application,
     12346: applicationApplyAgain,
-    ABCDE: applicationWithChoices
+    'ABCDE': applicationWithChoices,
+    45678: applicationWithSingleChoice
   },
   find_url: 'http://search-and-compare-ui-pr-442.herokuapp.com',
   flags: {

--- a/app/filters.js
+++ b/app/filters.js
@@ -157,7 +157,7 @@ module.exports = (env) => {
       // Application statuses
       case 'Submitted':
         return `${prefix}--grey`
-      case 'Awaiting application decision':
+      case 'Awaiting decision':
         return `${prefix}--purple`
       case 'Offer received':
         return `${prefix}--turquoise`

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -74,7 +74,7 @@ module.exports = router => {
           application.endedWithoutSuccess = true
           break
         case 'withdrawn':
-          choices[0].status = 'Withdrawn'
+          choices[0].status = 'Application withdrawn'
           application.endedWithoutSuccess = true
           break
         case 'offer-withdrawn':
@@ -165,7 +165,7 @@ module.exports = router => {
             providerName: 'Gorse SCITT',
             address: 'Clifford Moor Road, Boston Spa, West Yorkshire. LS23 6RW'
           }]
-          choices[1].status = 'Withdrawn'
+          choices[1].status = 'Application withdrawn'
           choices[1].interview = false
           choices[2].status = 'Offer received'
           application.endedWithoutSuccess = false

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -14,29 +14,33 @@ module.exports = router => {
 
       switch (applicationStatus) {
         // Single course states
-        case 'awaiting-decision':
-          choices[0].status = 'Awaiting provider decision'
+        case 'awaiting-provider-decision':
+          choices[0].status = 'Awaiting decision'
           choices[0].interview = false
+          application.endedWithoutSuccess = false
           break
         case 'future-interview':
-          choices[0].status = 'Awaiting provider decision'
+          choices[0].status = 'Awaiting decision'
           choices[0].interview = [{
             date: '2021-12-14T10:30:00',
             providerName: 'Leeds Trinity University',
             address: 'Brownberrie Lane, Horsforth, Leeds. LS18 5HD'
           }]
+          application.endedWithoutSuccess = false
           break
         case 'post-interview':
-          choices[0].status = 'Awaiting provider decision'
+          choices[0].status = 'Awaiting decision'
           choices[0].interview = [{
             date: '2019-12-14T10:30:00',
             providerName: 'Leeds Trinity University',
             address: 'Brownberrie Lane, Horsforth, Leeds. LS18 5HD'
           }]
+          application.endedWithoutSuccess = false
           break
         case 'offer-received':
           choices[0].status = 'Offer received'
           choices[0].interview = null
+          application.endedWithoutSuccess = false
           break
         case 'unsuccessful-with-feedback':
           choices[0].status = 'Unsuccessful'
@@ -51,6 +55,7 @@ module.exports = router => {
             },
             interested_in_future_applications: true
           }
+          application.endedWithoutSuccess = true
           break
         case 'unsuccessful-course-full':
           choices[0].status = 'Unsuccessful'
@@ -58,6 +63,7 @@ module.exports = router => {
           choices[0].feedback = {
             course_full: true
           }
+          application.endedWithoutSuccess = true
           break
         case 'unsuccessful-provider-did-not-respond':
           choices[0].status = 'Unsuccessful'
@@ -65,43 +71,51 @@ module.exports = router => {
           choices[0].feedback = {
             rejected_by_default: true
           }
+          application.endedWithoutSuccess = true
           break
         case 'withdrawn':
           choices[0].status = 'Withdrawn'
+          application.endedWithoutSuccess = true
           break
         case 'offer-withdrawn':
-          choices[0].status = 'Offer Withdrawn'
+          choices[0].status = 'Offer withdrawn'
+          application.endedWithoutSuccess = true
           break
 
         case 'accepted':
           choices[0].status = 'Offer accepted'
+          application.endedWithoutSuccess = false
           break
         case 'declined':
           choices[0].status = 'Offer declined'
+          application.endedWithoutSuccess = true
           break
         case 'deferred':
           choices[0].status = 'Offer deferred'
+          application.endedWithoutSuccess = false
           break
         case 'did-not-respond-to-offer':
           choices[0].status = 'Unsuccessful'
+          application.endedWithoutSuccess = true
           break
         case 'recruited-single':
           choices[0].status = 'Conditions met'
+          application.endedWithoutSuccess = false
           break
 
 
         // Multiple courses applied for
         case 'awaiting-provider-decisions':
-          choices[0].status = 'Awaiting application decision'
+          choices[0].status = 'Awaiting decision'
           choices[0].interview = false
-          choices[1].status = 'Awaiting application decision'
+          choices[1].status = 'Awaiting decision'
           choices[1].interview = false
-          choices[2].status = 'Awaiting application decision'
+          choices[2].status = 'Awaiting decision'
           choices[2].interview = false
           break
 
         case 'interviewing':
-          choices[0].status = 'Awaiting application decision'
+          choices[0].status = 'Awaiting decision'
           choices[0].interview = [{
             date: '2020-12-14T11:00:00',
             providerName: 'Gorse SCITT',
@@ -111,20 +125,20 @@ module.exports = router => {
             providerName: 'University of Leeds',
             address: 'Woodhouse, Leeds. LS2 9JT'
           }]
-          choices[1].status = 'Awaiting application decision'
+          choices[1].status = 'Awaiting decision'
           choices[1].interview = [{
             date: '2020-12-14T10:30:00',
             providerName: 'Leeds Trinity University',
             address: 'Brownberrie Lane, Horsforth, Leeds. LS18 5HD'
           }]
-          choices[2].status = 'Awaiting application decision'
+          choices[2].status = 'Awaiting decision'
           break
 
         case 'awaiting-candidate-response':
           choices[0].status = 'Unsuccessful'
           choices[0].hasFeedback = true
           choices[1].status = 'Offer received'
-          choices[2].status = 'Awaiting application decision'
+          choices[2].status = 'Awaiting decision'
           break
 
         case 'ended-without-success':
@@ -133,6 +147,7 @@ module.exports = router => {
           choices[1].status = 'Offer withdrawn'
           choices[1].hasFeedback = true
           choices[2].status = 'Application withdrawn'
+          application.endedWithoutSuccess = true
           break
 
         case 'pending-conditions':

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -98,6 +98,10 @@ module.exports = router => {
           choices[0].status = 'Unsuccessful'
           application.endedWithoutSuccess = true
           break
+        case 'conditions-not-met':
+          choices[0].status = 'Conditions not met'
+          application.endedWithoutSuccess = true
+          break
         case 'recruited-single':
           choices[0].status = 'Conditions met'
           application.endedWithoutSuccess = false

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -18,7 +18,6 @@ module.exports = router => {
           choices[0].status = 'Awaiting provider decision'
           choices[0].interview = false
           break
-        // Single course states
         case 'future-interview':
           choices[0].status = 'Awaiting provider decision'
           choices[0].interview = [{
@@ -39,6 +38,57 @@ module.exports = router => {
           choices[0].status = 'Offer received'
           choices[0].interview = null
           break
+        case 'unsuccessful-with-feedback':
+          choices[0].status = 'Unsuccessful'
+          choices[0].hasFeedback = true
+          choices[0].feedback = {
+            behaviour: false,
+            quality_of_application: {
+              subject_knowledge: "Understand the purpose of primary education and then learn more about the procedures related to safeguarding."
+            },
+            qualifications: {
+              degree_does_not_meet_requirements: true
+            },
+            interested_in_future_applications: true
+          }
+          break
+        case 'unsuccessful-course-full':
+          choices[0].status = 'Unsuccessful'
+          choices[0].hasFeedback = true
+          choices[0].feedback = {
+            course_full: true
+          }
+          break
+        case 'unsuccessful-provider-did-not-respond':
+          choices[0].status = 'Unsuccessful'
+          choices[0].hasFeedback = true
+          choices[0].feedback = {
+            rejected_by_default: true
+          }
+          break
+        case 'withdrawn':
+          choices[0].status = 'Withdrawn'
+          break
+        case 'offer-withdrawn':
+          choices[0].status = 'Offer Withdrawn'
+          break
+
+        case 'accepted':
+          choices[0].status = 'Offer accepted'
+          break
+        case 'declined':
+          choices[0].status = 'Offer declined'
+          break
+        case 'deferred':
+          choices[0].status = 'Offer deferred'
+          break
+        case 'did-not-respond-to-offer':
+          choices[0].status = 'Unsuccessful'
+          break
+        case 'recruited-single':
+          choices[0].status = 'Conditions met'
+          break
+
 
         // Multiple courses applied for
         case 'awaiting-provider-decisions':

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -13,6 +13,34 @@ module.exports = router => {
       choices = utils.toArray(choices)
 
       switch (applicationStatus) {
+        // Single course states
+        case 'awaiting-decision':
+          choices[0].status = 'Awaiting provider decision'
+          choices[0].interview = false
+          break
+        // Single course states
+        case 'future-interview':
+          choices[0].status = 'Awaiting provider decision'
+          choices[0].interview = [{
+            date: '2021-12-14T10:30:00',
+            providerName: 'Leeds Trinity University',
+            address: 'Brownberrie Lane, Horsforth, Leeds. LS18 5HD'
+          }]
+          break
+        case 'post-interview':
+          choices[0].status = 'Awaiting provider decision'
+          choices[0].interview = [{
+            date: '2019-12-14T10:30:00',
+            providerName: 'Leeds Trinity University',
+            address: 'Brownberrie Lane, Horsforth, Leeds. LS18 5HD'
+          }]
+          break
+        case 'offer-received':
+          choices[0].status = 'Offer received'
+          choices[0].interview = null
+          break
+
+        // Multiple courses applied for
         case 'awaiting-provider-decisions':
           choices[0].status = 'Awaiting application decision'
           choices[0].interview = false

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -109,13 +109,14 @@ module.exports = router => {
 
 
         // Multiple courses applied for
-        case 'awaiting-provider-decisions':
+        case 'awaiting-all-provider-decisions':
           choices[0].status = 'Awaiting decision'
           choices[0].interview = false
           choices[1].status = 'Awaiting decision'
           choices[1].interview = false
           choices[2].status = 'Awaiting decision'
           choices[2].interview = false
+          application.endedWithoutSuccess = false
           break
 
         case 'interviewing':
@@ -136,6 +137,51 @@ module.exports = router => {
             address: 'Brownberrie Lane, Horsforth, Leeds. LS18 5HD'
           }]
           choices[2].status = 'Awaiting decision'
+          application.endedWithoutSuccess = false
+
+          break
+
+        case 'awaiting-some-provider-decisions':
+          choices[0].status = 'Awaiting decision'
+          choices[0].interview = [{
+            date: '2020-12-14T11:00:00',
+            providerName: 'Gorse SCITT',
+            address: 'Clifford Moor Road, Boston Spa, West Yorkshire. LS23 6RW'
+          }]
+          choices[1].status = 'Unsuccessful'
+          choices[1].hasFeedback = true
+          choices[1].feedback = {
+            course_full: true
+          }
+          choices[2].status = 'Offer received'
+          choices[2].interview = null
+          application.endedWithoutSuccess = false
+          break
+
+        case 'received-one-offer':
+          choices[0].status = 'Unsuccessful'
+          choices[0].interview = [{
+            date: '2020-12-14T11:00:00',
+            providerName: 'Gorse SCITT',
+            address: 'Clifford Moor Road, Boston Spa, West Yorkshire. LS23 6RW'
+          }]
+          choices[1].status = 'Withdrawn'
+          choices[1].interview = false
+          choices[2].status = 'Offer received'
+          application.endedWithoutSuccess = false
+          break
+
+        case 'received-two-offers':
+          choices[0].status = 'Unsuccessful'
+          choices[0].interview = [{
+            date: '2020-12-14T11:00:00',
+            providerName: 'Gorse SCITT',
+            address: 'Clifford Moor Road, Boston Spa, West Yorkshire. LS23 6RW'
+          }]
+          choices[1].status = 'Offer received'
+          choices[1].interview = false
+          choices[2].status = 'Offer received'
+          application.endedWithoutSuccess = false
           break
 
         case 'awaiting-candidate-response':
@@ -155,21 +201,24 @@ module.exports = router => {
           break
 
         case 'pending-conditions':
-          choices[0].status = 'Offer accepted'
+          choices[0].status = 'Offer declined'
           choices[1].status = 'Application withdrawn'
-          choices[2].status = 'Offer declined'
+          choices[2].status = 'Offer accepted'
+          application.endedWithoutSuccess = false
           break
 
         case 'offer-deferred':
-          choices[0].status = 'Offer deferred'
+          choices[0].status = 'Offer declined'
           choices[1].status = 'Application withdrawn'
-          choices[2].status = 'Offer declined'
+          choices[2].status = 'Offer deferred'
+          application.endedWithoutSuccess = false
           break
 
         case 'recruited':
-          choices[0].status = 'Conditions met'
+          choices[0].status = 'Offer declined'
           choices[1].status = 'Application withdrawn'
-          choices[2].status = 'Offer declined'
+          choices[2].status = 'Conditions met'
+          application.endedWithoutSuccess = false
           break
 
         default:

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -118,7 +118,7 @@
     value: {
       html: interviewHtml
     }
-  } if item.interview and item.status == "Awaiting application decision", {
+  } if item.interview, {
     key: {
       text: "Feedback"
     },

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -42,15 +42,40 @@
 {% endset %}
 
 {% set feedbackHtml %}
-  <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Quality of application</h4>
-  <p class="govuk-body">Your subject knowledge could be improved.</p>
-  <p class="govuk-body">Details: Understand the purpose of primary education and then learn more about the procedures related to safeguarding.</p>
 
-  <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Qualifications</h4>
-  <p class="govuk-body">Your degree does not meet the course requirements.</p>
+  {% if item.feedback %}
+    {% if item.feedback.course_full %}
+      <h2 class="govuk-heading-s">Course was full</h2>
+      <p class="govuk-body">We're sorry to tell you the course you applied to was full</p>
+    {% endif %}
+    {% if item.feedback.rejected_by_default %}
+      <p class="govuk-body">Provider did not respond in time</p>
+    {% endif %}
 
-  <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Future applications</h4>
-  <p class="govuk-body">The provider would not be interested in future applications from you.</p>
+    {% if item.feedback.quality_of_application %}
+      <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Quality of application</h4>
+
+      {% if item.feedback.quality_of_application.subject_knowledge %}
+        <p class="govuk-body">Subject knowledge</p>
+        <p class="govuk-body">{{ item.feedback.quality_of_application.subject_knowledge }}</p>
+      {% endif %}
+
+    {% endif %}
+
+    {% if item.feedback.qualifications %}
+      <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Qualifications</h4>
+
+      {% if item.feedback.qualifications.degree_does_not_meet_requirements %}
+        <p class="govuk-body">Your degree does not meet the course requirements.</p>
+      {% endif %}
+    {% endif %}
+
+    {% if item.feedback.interested_in_future_applications %}
+      <h4 class="govuk-heading-s govuk-!-margin-bottom-0">Future applications</h4>
+      <p class="govuk-body">The provider would be interested in future applications from you.</p>
+    {% endif %}
+
+  {% endif  %}
 {% endset %}
 
 {{ govukSummaryList({

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -23,13 +23,12 @@
 
 
     {% set canWithdraw =
-      item.status == true
-      and (item.status != "Offer received")
+      (item.status != "Offer received")
       and (item.status != "Offer declined")
       and (item.status != "Application not sent")
       and (item.status != "Unsuccessful")
       and (item.status != "Offer withdrawn")
-      and (item.status != "Application withdrawn")
+      and (item.status != "Withdrawn")
     %}
 
     {{ appSummaryCard({

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -26,7 +26,7 @@
       and (item.status != "Application not sent")
       and (item.status != "Unsuccessful")
       and (item.status != "Offer withdrawn")
-      and (item.status != "Withdrawn")
+      and (item.status != "Application withdrawn")
       and (item.status != "Conditions not met")
     %}
 

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -29,6 +29,7 @@
       and (item.status != "Unsuccessful")
       and (item.status != "Offer withdrawn")
       and (item.status != "Withdrawn")
+      and (item.status != "Conditions not met")
     %}
 
     {{ appSummaryCard({

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -7,9 +7,7 @@
       {% include "_includes/item/choice.njk" %}
     {% endset %}
 
-    {% set canRespond = canMakeDecision
-      and item.status == "Offer received"
-    %}
+    {% set canRespond = item.status == "Offer received" %}
 
     {% set hasResponded =
       (item.status == "Conditions not met")

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -62,12 +62,21 @@
   <h3 class="govuk-heading-s">Applied for multiple courses</h3>
 
   <dl class="govuk-list app-list--definition">
-    <dt><a href="/dashboard/12345/awaiting-provider-decisions">Awaiting decisions from providers</a></dt>
-    <dd>We’ve sent the applications to the providers, but we have not heard back from all of them.</dd>
+    <dt><a href="/dashboard/12345/awaiting-all-provider-decisions">Awaiting decisions from all providers</a></dt>
+    <dd>We’ve sent the applications to the providers, but haven’t yet heard back from any of them</dd>
+
     <dt><a href="/dashboard/12345/interviewing">Interviewing</a></dt>
     <dd>Some providers have indicated that they’ve invited the candidate to interview.</dd>
-    <dt><a href="/dashboard/12345/awaiting-candidate-response">Awaiting decision from candidate</a></dt>
-    <dd>All providers have responded and it’s now up to the candidate to make a decision.</dd>
+
+    <dt><a href="/dashboard/12345/awaiting-some-provider-decisions">Some responses received, some still waiting</a></dt>
+    <dd>Candidate has received one offer and one rejection but is still waiting on the third provider</dd>
+
+    <dt><a href="/dashboard/12345/received-one-offer">Received one offer</a></dt>
+    <dd>All providers have responded and one offer has been made</dd>
+
+    <dt><a href="/dashboard/12345/received-two-offers">Received two offers</a></dt>
+    <dd>All providers have responded and two offers have been made</dd>
+
     <dt><a href="/dashboard/12345/ended-without-success">Ended without success</a></dt>
     <dd>All of the candidate’s applications have been withdrawn, rejected, declined or offer conditions were not met.</dd>
     <dt><a href="/dashboard/12345/pending-conditions">Accepted offer, pending conditions</a></dt>

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -52,6 +52,8 @@
     <dd>Candidate needs to meet conditions before next year</dd>
     <dt><a href="/dashboard/45678/did-not-respond-to-offer">Candidate did not respond to offer in time</a></dt>
     <dd>Candidate can apply again</dd>
+    <dt><a href="/dashboard/45678/conditions-not-met">Candidate did not meet offer conditions in time</a></dt>
+    <dd>Candidate can apply again</dd>
     <dt><a href="/dashboard/45678/recruited-single">Candidate recruited</a></dt>
     <dd>Signposting of onward services?</dd>
 

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -34,13 +34,15 @@
     <dd>Candidate needs to wait</dd>
     <dt><a href="/dashboard/45678/offer-received">Received an offer with conditions</a></dt>
     <dd>Candidate needs to respond to the offer</dd>
-    <dt><a href="/dashboard/45678/unsuccesful-with-feedback">Unsuccessful - provider has given feedback</a></dt>
+    <dt><a href="/dashboard/45678/unsuccessful-with-feedback">Unsuccessful - provider has given feedback</a></dt>
     <dd>Candidate can apply again using feedback</dd>
-    <dt><a href="/dashboard/45678/unsuccesful-course-full">Unsuccessful - course was full</a></dt>
+    <dt><a href="/dashboard/45678/unsuccessful-course-full">Unsuccessful - course was full</a></dt>
     <dd>Candidate can apply again</dd>
-    <dt><a href="/dashboard/45678/unsuccesful-provider-did-not-respond">Unsuccessful - provider did not respond in time</a></dt>
+    <dt><a href="/dashboard/45678/unsuccessful-provider-did-not-respond">Unsuccessful - provider did not respond in time</a></dt>
     <dd>Candidate can apply again</dd>
-    <dt><a href="/dashboard/45678/withdrawn">Withdrawn</a></dt>
+    <dt><a href="/dashboard/45678/withdrawn">Candidate withdrew application</a></dt>
+    <dd>Candidate can apply again</dd>
+    <dt><a href="/dashboard/45678/offer-withdrawn">Offer withdrawn by provider</a></dt>
     <dd>Candidate can apply again</dd>
     <dt><a href="/dashboard/45678/accepted">Accepted (pending conditions)</a></dt>
     <dd>Candidate needs to meet the conditions</dd>
@@ -50,7 +52,7 @@
     <dd>Candidate needs to meet conditions before next year</dd>
     <dt><a href="/dashboard/45678/did-not-respond-to-offer">Candidate did not respond to offer in time</a></dt>
     <dd>Candidate can apply again</dd>
-    <dt><a href="/dashboard/45678/recruited">Candidate recruited</a></dt>
+    <dt><a href="/dashboard/45678/recruited-single">Candidate recruited</a></dt>
     <dd>Signposting of onward services?</dd>
 
   </dl>

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -21,7 +21,42 @@
     <dd>The candidate has started apply again but has not submitted the form yet.</dd>
   </dl>
 
-  <h2 class="govuk-heading-m">Dashboard</h2>
+  <h2 class="govuk-heading-m">Post-submission</h2>
+
+  <h3 class="govuk-heading-s">Applied for a single course</h3>
+
+  <dl class="govuk-list app-list--definition">
+    <dt><a href="/dashboard/45678/awaiting-provider-decision">Awaiting decision from provider</a></dt>
+    <dd>Candidate needs to wait</dd>
+    <dt><a href="/dashboard/45678/future-interview">Interview scheduled in future</a></dt>
+    <dd>Candidate needs to attend interview</dd>
+    <dt><a href="/dashboard/45678/post-interview">After interview, still awaiting decision</a></dt>
+    <dd>Candidate needs to wait</dd>
+    <dt><a href="/dashboard/45678/offer-received">Received an offer with conditions</a></dt>
+    <dd>Candidate needs to respond to the offer</dd>
+    <dt><a href="/dashboard/45678/unsuccesful-with-feedback">Unsuccessful - provider has given feedback</a></dt>
+    <dd>Candidate can apply again using feedback</dd>
+    <dt><a href="/dashboard/45678/unsuccesful-course-full">Unsuccessful - course was full</a></dt>
+    <dd>Candidate can apply again</dd>
+    <dt><a href="/dashboard/45678/unsuccesful-provider-did-not-respond">Unsuccessful - provider did not respond in time</a></dt>
+    <dd>Candidate can apply again</dd>
+    <dt><a href="/dashboard/45678/withdrawn">Withdrawn</a></dt>
+    <dd>Candidate can apply again</dd>
+    <dt><a href="/dashboard/45678/accepted">Accepted (pending conditions)</a></dt>
+    <dd>Candidate needs to meet the conditions</dd>
+    <dt><a href="/dashboard/45678/declined">Declined</a></dt>
+    <dd>Candidate can apply again</dd>
+    <dt><a href="/dashboard/45678/deferred">Deferred</a></dt>
+    <dd>Candidate needs to meet conditions before next year</dd>
+    <dt><a href="/dashboard/45678/did-not-respond-to-offer">Candidate did not respond to offer in time</a></dt>
+    <dd>Candidate can apply again</dd>
+    <dt><a href="/dashboard/45678/recruited">Candidate recruited</a></dt>
+    <dd>Signposting of onward services?</dd>
+
+  </dl>
+
+  <h3 class="govuk-heading-s">Applied for multiple courses</h3>
+
   <dl class="govuk-list app-list--definition">
     <dt><a href="/dashboard/12345/awaiting-provider-decisions">Awaiting decisions from providers</a></dt>
     <dd>We’ve sent the applications to the providers, but we have not heard back from all of them.</dd>

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -16,6 +16,9 @@
 {% elif status == "awaiting-candidate-response" %}
   {% set statusTitle = "All your training providers have now reached a decision" %}
   {% set statusDesc = "You have 14 days (until " + 14 | nowPlusDays("d MMMM yyyy") + ") to respond to any offers. If you do not respond, your applications will be automatically withdrawn." %}
+{% elif status == "offer-received" %}
+  {% set statusTitle = "Your training provider has now reached a decision" %}
+  {% set statusDesc = "You have 14 days (until " + 14 | nowPlusDays("d MMMM yyyy") + ") to respond to any offers. If you do not respond, your applications will be automatically withdrawn." %}
 {% elif status == "ended-without-success" %}
   {% set statusTitle = "All your training providers have now reached a decision" %}
 {% elif status == "withdrawn" %}
@@ -26,7 +29,7 @@
 {% elif status == "offer-deferred" %}
   {% set statusTitle = "Your original offer has been deferred" %}
   {% set statusDesc = "We’ve sent you an email to confirm this. Your training provider will be in touch with you directly to explain what happens next." %}
-{% elif status == "recruited" %}
+{% elif status == "recruited" or status == "recruited-single" %}
   {% set statusTitle = "You have met your conditions and are ready to be enrolled" %}
   {% set statusDesc = "Your training provider will be in touch with you directly to explain what happens next." %}
 {% else %}
@@ -39,9 +42,11 @@
 {% endif %}
 
 {% block beforePageTitle %}
-  {{ govukNotificationBanner({
-    html: "<p class=\"govuk-notification-banner__heading\">You did not get a place on a course this time. <a class=\"govuk-notification-banner__link\" href=\"" + applicationPath + "/apply-again\">Apply again</a>.</p>"
-  }) if status == "ended-without-success" }}
+  {% if application.endedWithoutSuccess == true %}
+    {{ govukNotificationBanner({
+      html: "<p class=\"govuk-notification-banner__heading\">You did not get a place on a course this time. <a class=\"govuk-notification-banner__link\" href=\"" + applicationPath + "/apply-again\">Apply again</a>.</p>"
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block beforePrimary %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -10,16 +10,13 @@
   {% set referrer = "/dashboard/" + applicationId %}
 {% endif %}
 
-{% if status == "awaiting-provider-decisions" or status == "interviewing" %}
-  {% set statusTitle = "Some of your training providers have not reached a decision yet" %}
-  {% set statusDesc = "Training providers must respond by " + 56 | nowPlusDays("d MMMM yyyy") + "." %}
-{% elif status == "awaiting-candidate-response" %}
+{% if status == "awaiting-candidate-response" %}
   {% set statusTitle = "All your training providers have now reached a decision" %}
   {% set statusDesc = "You have 14 days (until " + 14 | nowPlusDays("d MMMM yyyy") + ") to respond to any offers. If you do not respond, your applications will be automatically withdrawn." %}
 {% elif status == "offer-received" %}
   {% set statusTitle = "Your training provider has now reached a decision" %}
   {% set statusDesc = "You have 14 days (until " + 14 | nowPlusDays("d MMMM yyyy") + ") to respond to any offers. If you do not respond, your applications will be automatically withdrawn." %}
-{% elif status == "ended-without-success" %}
+{% elif status == "ended-without-success" or status == "received-one-offer" %}
   {% set statusTitle = "All your training providers have now reached a decision" %}
 {% elif status == "withdrawn" %}
   {% set statusTitle = "You have withdrawn all your choices" %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -10,15 +10,15 @@
   {% set referrer = "/dashboard/" + applicationId %}
 {% endif %}
 
-{% if status == "awaiting-candidate-response" %}
+{% if status == "awaiting-candidate-response" or status == "received-one-offer" or status == "received-two-offers" %}
   {% set statusTitle = "All your training providers have now reached a decision" %}
   {% set statusDesc = "You have 14 days (until " + 14 | nowPlusDays("d MMMM yyyy") + ") to respond to any offers. If you do not respond, your applications will be automatically withdrawn." %}
 {% elif status == "offer-received" %}
   {% set statusTitle = "Your training provider has now reached a decision" %}
   {% set statusDesc = "You have 14 days (until " + 14 | nowPlusDays("d MMMM yyyy") + ") to respond to any offers. If you do not respond, your applications will be automatically withdrawn." %}
-{% elif status == "ended-without-success" or status == "received-one-offer" %}
+{% elif status == "ended-without-success" %}
   {% set statusTitle = "All your training providers have now reached a decision" %}
-{% elif status == "withdrawn" %}
+{% elif status == "withdrawn" or status == "did-not-respond-to-offer" %}
   {% set statusTitle = "You have withdrawn all your choices" %}
 {% elif status == "pending-conditions" %}
   {% set statusTitle = "You have accepted an offer" %}

--- a/app/views/dashboard/index.njk
+++ b/app/views/dashboard/index.njk
@@ -10,7 +10,7 @@
   {% set referrer = "/dashboard/" + applicationId %}
 {% endif %}
 
-{% if status == "awaiting-provider-decisions" or "interviewing" %}
+{% if status == "awaiting-provider-decisions" or status == "interviewing" %}
   {% set statusTitle = "Some of your training providers have not reached a decision yet" %}
   {% set statusDesc = "Training providers must respond by " + 56 | nowPlusDays("d MMMM yyyy") + "." %}
 {% elif status == "awaiting-candidate-response" %}
@@ -30,8 +30,12 @@
   {% set statusTitle = "You have met your conditions and are ready to be enrolled" %}
   {% set statusDesc = "Your training provider will be in touch with you directly to explain what happens next." %}
 {% else %}
-  {% set statusTitle = "Courses you’ve applied to" %}
-  {% set statusDesc = false %}
+  {% if application.choices | toArray | length > 1 %}
+    {% set statusTitle = "Courses you’ve applied to" %}
+  {% else %}
+    {% set statusTitle = "Course you’ve applied to" %}
+  {% endif %}
+  {% set statusDesc = "Training providers must respond by " + 56 | nowPlusDays("d MMMM yyyy") + "." %}
 {% endif %}
 
 {% block beforePageTitle %}
@@ -46,7 +50,8 @@
 {% endblock %}
 
 {% block primary %}
-  {% set canMakeDecision = (status == "awaiting-provider-decisions") or (status == "awaiting-candidate-response") %}
+
+  {% set canMakeDecision = (status == "awaiting-provider-decisions") or (status == "awaiting-candidate-response" or status == "offer-received") %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">{{ statusTitle }}</h2>
   {% if statusDesc %}


### PR DESCRIPTION
This updates the prototype to show more different states and combinations of states in the post-submission phase.  These mostly now reflect the current production design (although the apply again prompt is still a bit different).

There is some information deliberately missing, as it hasn't yet been added to the live service:

* offer conditions (once accepted)
* reasons given by the provider for withdrawing an offer
* reasons given by a candidate for declining an offer or withdrawing an application
* ability to see previous applications and outcomes (if applying again)

This PR is mainly just laying groundwork for a rethink and review of these sections.