### PR TITLE
Fix: Show status as "Offer declined" if declined by default

### DIFF
--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -95,7 +95,7 @@ module.exports = router => {
           application.endedWithoutSuccess = false
           break
         case 'did-not-respond-to-offer':
-          choices[0].status = 'Unsuccessful'
+          choices[0].status = 'Offer declined'
           application.endedWithoutSuccess = true
           break
         case 'conditions-not-met':


### PR DESCRIPTION
Fix: If a candidate doesn't respond to an offer before the deadline, the status is shown as "Offer declined" not "Unsuccessful".