### PR TITLE
Change dash to "to" between months

### DIFF
--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -89,7 +89,7 @@
               (estimate)
             {% endif %}
 
-            –
+            to
             {% if item["end-date-present"] == "yes" %}
               Present
             {% else %}


### PR DESCRIPTION
The [GOV.UK style guide](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges) says:

> Use ‘to’ instead of a dash or slash in date ranges. ‘To’ is quicker to read than a dash, and it’s easier for screen readers.

Thanks @adamsilver for spotting this.