### PR TITLE
Make the use of GOV.UK Notify optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This prototype is based on the [GOV.UK prototype kit](https://github.com/alphago
 
 If you want to skip installing dependencies each time, you can instead type `npm run s`.
 
+If you want to also test the email notifications, you can get an API key for GOV.UK Notify and add it to a `.env` file after `NOTIFYAPIKEY=`.
+
 ## Available user journeys
 
 ### Creating an account

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -4,8 +4,12 @@ dotenv.config()
 
 const querystring = require('querystring')
 const { DateTime } = require('luxon')
-const NotifyClient = require('notifications-node-client').NotifyClient
-const notify = new NotifyClient(process.env.NOTIFYAPIKEY)
+
+if (process.env.NOTIFYAPIKEY) {
+  const NotifyClient = require('notifications-node-client').NotifyClient
+  const notify = new NotifyClient(process.env.NOTIFYAPIKEY)
+}
+
 const providers = require('./../data/providers')
 
 const applicationData = (req) => {
@@ -69,7 +73,7 @@ const sendEmail = (req, template, personalisation) => {
   personalisation = personalisation || {}
   personalisation.url = req.get('origin') || `${req.protocol}://${req.get('host')}`
 
-  if (email) {
+  if (email && notify) {
     notify.sendEmail(
       template,
       email,


### PR DESCRIPTION
When switching to a new machine, it took me a good few minutes to decrypt this error message, caused by the lack of the Notify API key, and look up what the expected environment variable should be:

```bash
/apply-for-teacher-training-prototype/node_modules/notifications-node-client/client/api_client.js:20
    this.apiKeyId = arguments[0].substring(arguments[0].length - 36, arguments[0].length);
                                 ^

TypeError: Cannot read property 'substring' of undefined
```

This changes makes the use of Notify optional, enabling a faster start for designers and developers who don’t need to test email notifications.