### PR TITLE
Update personal details review page

### DIFF
--- a/app/views/_includes/review/personal-details.njk
+++ b/app/views/_includes/review/personal-details.njk
@@ -91,7 +91,7 @@
       } if canAmend
     }, {
       key: {
-        text: "Residency status"
+        text: "Immigration status"
       },
       value: {
         html: residencyText


### PR DESCRIPTION
Update personal details review page to be consistent with residency page.

We've changed the label for the Yes radio text box to: 'What is your immigration status?'

On the review page, the label is 'Residency status' - change this to 'Immigration status' for consistency and to avoid any confusion.