### PR TITLE
Dashboard content design tweaks

### DIFF
--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -199,8 +199,7 @@ module.exports = router => {
         choices.ABCDE.interview = [{
           date: DateTime.local().set({hour: 10, minute: 30}).plus({ days: 7 }),
           providerName: 'University of Leeds',
-          address: 'Please use this link to attend the interview on Zoom:\n\n<a href="#">https://zoom.us/https://us02web.zoom.us/j/35346436342?pwd=bk43RStvSnFHK1NQZnVp6D3DFTSJFGNS</a><br><br>You may need to download the Zoom app first.',
-          additional_details: 'The interview panel will consist of Gemma (training lead) and Brian (recruitment officer)'
+          address: 'Zoom: <a href="#">https://zoom.us/https://us02web.zoom.us/j/35346436342?pwd=bk43RStvSnFHK1NQZnVp6D3DFTSJFGNS</a>'
         }]
         choices.FGHIJ.status = 'Awaiting decision'
         choices.FGHIJ.interview = [{
@@ -217,8 +216,7 @@ module.exports = router => {
         choices.ABCDE.interview = [{
           date: DateTime.local().set({hour: 10, minute: 30}).plus({ days: 7 }),
           providerName: 'University of Leeds',
-          address: 'Please use this link to attend the interview on Zoom:\n\n<a href="#">https://zoom.us/https://us02web.zoom.us/j/35346436342?pwd=bk43RStvSnFHK1NQZnVp6D3DFTSJFGNS</a><br><br>You may need to download the Zoom app first.',
-          additional_details: 'The interview panel will consist of Gemma (training lead) and Brian (recruitment officer)'
+          address: 'Zoom: <a href="#">https://zoom.us/https://us02web.zoom.us/j/35346436342?pwd=bk43RStvSnFHK1NQZnVp6D3DFTSJFGNS</a>'
         }]
         choices.FGHIJ.status = 'Unsuccessful'
         choices.FGHIJ.feedback = {

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -214,7 +214,7 @@ module.exports = router => {
       case 'awaiting-one-provider-decision-one-offer':
         choices.ABCDE.status = 'Awaiting decision'
         choices.ABCDE.interview = [{
-          date: DateTime.local().set({hour: 10, minute: 30}).plus({ days: 7 }),
+          date: DateTime.local().set({hour: 10, minute: 30}).minus({ days: 2 }),
           providerName: 'University of Leeds',
           address: 'Zoom: <a href="#">https://zoom.us/https://us02web.zoom.us/j/35346436342?pwd=bk43RStvSnFHK1NQZnVp6D3DFTSJFGNS</a>'
         }]

--- a/app/routes/application/decision.js
+++ b/app/routes/application/decision.js
@@ -13,12 +13,17 @@ module.exports = router => {
     const provider = providers[choice.providerCode]
     const course = provider.courses[choice.courseCode]
 
+    const numberOfOffersReceived = utils.toArray(application.choices).filter(function(choice) {
+      return choice.status == "Offer received"
+    }).length
+
     res.render(`application/decision/${req.params.view}`, {
       provider,
       course,
       choice,
       choiceId,
-      referrer
+      referrer,
+      numberOfOffersReceived
     })
   })
 

--- a/app/views/_includes/item/offer.njk
+++ b/app/views/_includes/item/offer.njk
@@ -3,7 +3,7 @@
     <li>Fitness to teach check</li>
     <li>Disclosure and Barring Service check</li>
   </ul>
-  <p>For help understanding or meeting your conditions, contact {{ provider.name }} directly</p>
+  <p>Contact the provider to find out more about these conditions.</p>
 {% endset %}
 
 {{ govukSummaryList({

--- a/app/views/application/decision/view.njk
+++ b/app/views/application/decision/view.njk
@@ -12,11 +12,15 @@
 
 {% block primary %}
   {% include "_includes/item/offer.njk" %}
-  <p class="govuk-body">Remember:</p>
+
+  <p class="govuk-body">Before you accept:</p>
+
   <ul class="govuk-list govuk-list--bullet">
-    <li>you can only accept one offer, across both Apply for teacher training and UCAS teacher training</li>
-    <li>if you fail to respond, or you decline all your offers, you can still apply to other courses this year through <a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do">UCAS Teacher Training</a></li>
-    <li>you can register with <a href="https://getintoteaching.education.gov.uk/">Get Into Teaching</a> to get help from a teacher training advisor</li>
+    <li>if you accept this offer, you cannot also accept another offer through UCAS teacher training</li>
+    {% if numberOfOffersReceived > 1 %}
+      <li>if you accept this offer, your other {{ "offer" if numberOfOffersReceived == 2 else "offers"}} will be automatically declined</li>
+    {% endif %}
+    <li>if you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year</li>
   </ul>
 
   {{ govukRadios({

--- a/app/views/dashboard/_confirmation_banner.njk
+++ b/app/views/dashboard/_confirmation_banner.njk
@@ -4,6 +4,7 @@
   <h3 class="govuk-notification-banner__heading">
     Application successfully submitted
   </h3>
+  <p class="govuk-body"> You will get an email when something changes.</p>
 {% endset %}
 
 {{ govukNotificationBanner({

--- a/app/views/dashboard/_course-choice-conditions.njk
+++ b/app/views/dashboard/_course-choice-conditions.njk
@@ -4,4 +4,5 @@
       <li>{{ condition }}</li>
     {% endfor %}
   </ul>
+  <p class="govuk-body">Contact the provider to find out more about these conditions.</p>
 {% endif %}

--- a/app/views/dashboard/_course-choice-interview.njk
+++ b/app/views/dashboard/_course-choice-interview.njk
@@ -1,25 +1,31 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-{% for interview in item.interview %}
-  {% if (interview.date | date) > ("" | dateNow() | date) %}
-    <p class="govuk-body">You have an interview scheduled for {{ interview.date | date("d LLLL yyyy, h:mma") }}</p>
+{% if item.interview %}
+  {% for interview in item.interview %}
+    {% if (interview.date | date) > ("" | dateNow() | date) %}
+      <p class="govuk-body">You have an interview scheduled for {{ interview.date | date("d LLLL yyyy, h:mma") }}</p>
 
-    <p class="govuk-body govuk-!-margin-bottom-0">Details from provider:</p>
+      <p class="govuk-body govuk-!-margin-bottom-0">Information from provider:</p>
 
-    {% set interviewDetails %}
-      <p class="govuk-body">{{ interview.address | safe }}</p>
+      {% set interviewDetails %}
+        <p class="govuk-body">{{ interview.address | safe }}</p>
 
-      {% if interview.additional_details %}
-        <p class="govuk-body">{{ interview.additional_details | safe }}</p>
-      {% endif %}
-    {% endset %}
+        {% if interview.additional_details %}
+          <p class="govuk-body">{{ interview.additional_details | safe }}</p>
+        {% endif %}
+      {% endset %}
 
-    {{ govukInsetText({
-      html: interviewDetails,
-      classes: "govuk-!-margin-top-1"
-    }) }}
+      {{ govukInsetText({
+        html: interviewDetails,
+        classes: "govuk-!-margin-top-1 govuk-!-margin-bottom-1"
+      }) }}
 
-  {% else %}
-    <p class="govuk-body">You had an interview scheduled for {{ interview.date | date("d LLLL yyyy") }}</p>
-  {% endif %}
-{% endfor %}
+      <p class="govuk-body">The provider will send more details about the interview by email.</p>
+
+    {% else %}
+      <p class="govuk-body">You had an interview on {{ interview.date | date("d LLLL yyyy") }}</p>
+    {% endif %}
+  {% endfor %}
+{% else %}
+  The provider will be in touch if they want to invite you to an interview.
+{% endif %}

--- a/app/views/dashboard/_course-choices.njk
+++ b/app/views/dashboard/_course-choices.njk
@@ -108,7 +108,7 @@
         value: {
           html: interviewHtml | safe
         }
-      } if not canRespond, {
+      } if not canRespond and item.status != "Unsuccessful", {
         key: {
           text: "Feedback"
         },

--- a/app/views/dashboard/_course-choices.njk
+++ b/app/views/dashboard/_course-choices.njk
@@ -73,6 +73,14 @@
     {% endif %}
     {% if canRespond and not hasResponded %}
       <p class="govuk-body"><a href="{{ applicationPath + "/" + item.id + "/view" }}">Respond to offer</a></p>
+
+      <p class="govuk-body">
+        {% if numberOfChoicesAwaitingDecision > 0 %}
+          You can wait to hear back from everyone before you respond.
+        {% else %}
+          You have 14 days (until 19 March 2021) to respond.
+        {% endif %}
+      </p>
     {% endif %}
   {% endset %}
 

--- a/app/views/dashboard/_course-choices.njk
+++ b/app/views/dashboard/_course-choices.njk
@@ -100,7 +100,7 @@
         value: {
           html: interviewHtml | safe
         }
-      } if item.interview and not canRespond, {
+      } if not canRespond, {
         key: {
           text: "Feedback"
         },

--- a/app/views/dashboard/_guidance.njk
+++ b/app/views/dashboard/_guidance.njk
@@ -6,15 +6,11 @@
     <p class="govuk-body">Your application has been submitted and is with the training provider.</p>
   {% endif %}
 
-  <p class="govuk-body">They will be in touch if they want to invite you to an interview.</p>
-
-  <p class="govuk-body">If you have been asked to attend an interview our <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training advisers</a> can help you prepare.</p>
+  <p class="govuk-body">Our <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training advisers</a> can help you prepare for any interviews.</p>
 
 {% elif numberOfOffersReceived > 0 and numberOfChoicesAwaitingDecision > 0 %}
 
   <p class="govuk-body">{{ "One" if numberOfOffersReceived == 1 else "Two" }} of your training providers has made a decision on your application.</p>
-
-  <p class="govuk-body">You can wait to hear back from everyone before you make a decision.</p>
 
   <p class="govuk-body">If you have been asked to attend an interview our <a href="#">teacher training advisers</a> can help you prepare.</p>
 

--- a/app/views/dashboard/_guidance.njk
+++ b/app/views/dashboard/_guidance.njk
@@ -12,7 +12,7 @@
 
   <p class="govuk-body">{{ "One" if numberOfOffersReceived == 1 else "Two" }} of your training providers has made a decision on your application.</p>
 
-  <p class="govuk-body">If you have been asked to attend an interview our <a href="#">teacher training advisers</a> can help you prepare.</p>
+  <p class="govuk-body">Our <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training advisers</a> can help you prepare for any interviews.</p>
 
 {% elif choices | length == 1 and choices[0].status == "Offer accepted" %}
 


### PR DESCRIPTION
Content tweaks following user research.

Changes:

* "Details from provider:" changed to "Information from provider" as it’s often not that detailed.
* Added line "The provider will send more details about the interview by email." beneath interview content given by provider.
* Changed "You had an interview scheduled for..." to "You had an interview on..." to help differentiate it from future tense and to remove implication that you might not have attended.
* Added line "The provider will be in touch if they want to invite you to an interview." if the course is awaiting decision but no interviews schedule yet, rather than displaying this at the top of the page.
* Moved "You can wait to hear back from everyone before you make a decision." from the top of the page to beneath the "Respond to offer" links to make it more visible at the point you might be considering responding.
* Repeated the "You have 14 days (until 19 March 2021) to respond." line beneath the "Respond to offer" link when you have a deadline to respond by.
* Copy-edited "If you have been asked to attend an interview our teacher training advisers can help you prepare." down to "Our teacher training advisers can help you prepare for any interviews."
* Add line "You will get an email when something changes." to confirmation banner.
* Add line "Contact the provider to find out more about these conditions." to dashboard and offer pages.
* Update bullet point content on offer pages.


## Screenshots

### Before

<img width="703" alt="Screenshot 2021-03-15 at 16 12 29" src="https://user-images.githubusercontent.com/30665/111184868-4e9fe100-85a9-11eb-86df-4be06d557160.png">

### After

<img width="669" alt="Screenshot 2021-03-15 at 16 11 29" src="https://user-images.githubusercontent.com/30665/111184897-565f8580-85a9-11eb-9e7c-3e3fe72df85e.png">

### Before

<img width="654" alt="Screenshot 2021-03-15 at 16 14 12" src="https://user-images.githubusercontent.com/30665/111185095-8a3aab00-85a9-11eb-8d02-228953ff3f1c.png">

### After

<img width="663" alt="Screenshot 2021-03-15 at 16 14 24" src="https://user-images.githubusercontent.com/30665/111185115-90c92280-85a9-11eb-8050-03522ba0d949.png">

### Before

<img width="661" alt="Screenshot 2021-03-15 at 16 15 21" src="https://user-images.githubusercontent.com/30665/111185362-cc63ec80-85a9-11eb-9684-58cd9e2cdd9c.png">

### After

<img width="667" alt="Screenshot 2021-03-15 at 16 16 12" src="https://user-images.githubusercontent.com/30665/111185337-c4a44800-85a9-11eb-9c53-a97593590747.png">

### Before

<img width="673" alt="Screenshot 2021-03-15 at 16 17 22" src="https://user-images.githubusercontent.com/30665/111185514-f4535000-85a9-11eb-9eab-7ed5a74cc94a.png">

### After

<img width="671" alt="Screenshot 2021-03-15 at 16 16 56" src="https://user-images.githubusercontent.com/30665/111185540-fc12f480-85a9-11eb-8a3a-33ace18abadb.png">

<img width="657" alt="Screenshot 2021-03-15 at 16 18 07" src="https://user-images.githubusercontent.com/30665/111185610-0fbe5b00-85aa-11eb-89d5-54a1fa52535e.png">

### Before

<img width="1028" alt="Screenshot 2021-03-15 at 16 19 21" src="https://user-images.githubusercontent.com/30665/111185764-3b414580-85aa-11eb-8a99-4345f6b72289.png">

### After

<img width="1012" alt="Screenshot 2021-03-15 at 16 20 00" src="https://user-images.githubusercontent.com/30665/111185828-4c8a5200-85aa-11eb-8bfa-2a92e2763b1d.png">

### Before

<img width="681" alt="Screenshot 2021-03-15 at 16 20 36" src="https://user-images.githubusercontent.com/30665/111185907-62981280-85aa-11eb-8e45-41cdf6476363.png">

### After

<img width="692" alt="Screenshot 2021-03-15 at 16 21 18" src="https://user-images.githubusercontent.com/30665/111185997-7ba0c380-85aa-11eb-90fd-0349c41b73c3.png">
