### PR TITLE
Post flight check spike fixes

### DIFF
--- a/app/data/application-apply-again-with-choice.js
+++ b/app/data/application-apply-again-with-choice.js
@@ -6,6 +6,8 @@ applicationApplyAgainWithChoice.apply2 = true
 applicationApplyAgainWithChoice.previousApplications = ['12345']
 
 // No choices yet
-applicationApplyAgainWithChoice.choices = {'ABCDE': applicationApplyAgainWithChoice.choices['ABCDE']}
+applicationApplyAgainWithChoice.choices = {
+  ABCDE: applicationApplyAgainWithChoice.choices.ABCDE
+}
 
 module.exports = applicationApplyAgainWithChoice

--- a/app/data/application-international.js
+++ b/app/data/application-international.js
@@ -287,7 +287,5 @@ module.exports = {
       'end-date': 'now'
     }
   },
-  'school-experience': {
-    attained: 'false'
-  }
+  'school-experience-decision': 'No'
 }

--- a/app/data/application-international.js
+++ b/app/data/application-international.js
@@ -287,5 +287,6 @@ module.exports = {
       'end-date': 'now'
     }
   },
-  'school-experience-decision': 'No'
+  'school-experience-decision': 'No',
+  'school-experience': {}
 }

--- a/app/data/application-single-choice.js
+++ b/app/data/application-single-choice.js
@@ -1,7 +1,8 @@
 // Copies dummy application and tweaks some fields
 const application = JSON.parse(JSON.stringify(require('./application')))
 
-
-application.choices = {'ABCDE': application.choices['ABCDE']}
+application.choices = {
+  ABCDE: application.choices.ABCDE
+}
 
 module.exports = application

--- a/app/data/application-with-choices.js
+++ b/app/data/application-with-choices.js
@@ -2,7 +2,4 @@
 const application = JSON.parse(JSON.stringify(require('./application')))
 
 // No completed sections yet
-
-
-
 module.exports = application

--- a/app/data/application.js
+++ b/app/data/application.js
@@ -245,7 +245,5 @@ module.exports = {
       'end-date': 'now'
     }
   },
-  'school-experience': {
-    attained: 'false'
-  }
+  'school-experience-decision': 'No'
 }

--- a/app/data/application.js
+++ b/app/data/application.js
@@ -138,7 +138,7 @@ module.exports = {
     }
   },
   'reasonable-adjustments': {
-    disclose: 'false'
+    disclose: 'No'
   },
   suitability: {
     disclose: 'No'

--- a/app/data/application.js
+++ b/app/data/application.js
@@ -141,7 +141,7 @@ module.exports = {
     disclose: 'false'
   },
   suitability: {
-    disclose: 'false'
+    disclose: 'No'
   },
   degree: {
     abcde: {
@@ -157,7 +157,6 @@ module.exports = {
       grade: 'Lower second-class honours (2:2)'
     }
   },
-  'other-qualifications': {},
   gcse: {
     maths: {
       id: 'maths',

--- a/app/data/application.js
+++ b/app/data/application.js
@@ -245,5 +245,6 @@ module.exports = {
       'end-date': 'now'
     }
   },
-  'school-experience-decision': 'No'
+  'school-experience-decision': 'No',
+  'school-experience': {}
 }

--- a/app/routes/application/school-experience.js
+++ b/app/routes/application/school-experience.js
@@ -60,14 +60,9 @@ module.exports = router => {
   router.post('/application/:applicationId/school-experience/answer', (req, res) => {
     const { applicationId } = req.params
     const application = utils.applicationData(req)
-    const schoolExperience = application['school-experience']
+    const schoolExperienceDecision = application['school-experience-decision']
 
-    let attained
-    if (schoolExperience) {
-      attained = application['school-experience'].attained
-    }
-
-    if (attained === 'false') {
+    if (schoolExperienceDecision === 'No') {
       res.redirect(`/application/${applicationId}/school-experience/review`)
     } else {
       res.redirect(`/application/${applicationId}/school-experience/add/role`)

--- a/app/views/_includes/item/school-experience.njk
+++ b/app/views/_includes/item/school-experience.njk
@@ -1,33 +1,34 @@
 {% set schoolExperience = applicationValue(["school-experience"]) %}
 {% set roles = schoolExperience | toArray | selectattr("id") | sort(attribute="start-date") %}
 
-{% set summaryCardHtml %}
-  {% if roles.length >= 1 %}
-    {% for item in roles %}
-      {% set roleHtml %}
-        {% include "_includes/item/role.njk" %}
-      {% endset %}
-      {{ appSummaryCard({
-        classes: "govuk-!-margin-bottom-6",
-        headingLevel: 3,
-        titleHtml: item.role,
-        actions: {
-          items: [{
-            href: applicationPath + "/school-experience/" + item.id + "/delete?referrer=" + referrer,
-            text: "Delete role"
-          }]
-        } if canAmend,
-        html: roleHtml
-      }) }}
-    {% endfor %}
-  {% elif applicationValue(["school-experience","attained"]) == "false" %}
-    {{ govukSummaryList({
+{% if roles.length >= 1 %}
+  {% for item in roles %}
+    {% set roleHtml %}
+      {% include "_includes/item/role.njk" %}
+    {% endset %}
+    {{ appSummaryCard({
+      classes: "govuk-!-margin-bottom-6",
+      headingLevel: 3,
+      titleHtml: item.role,
+      actions: {
+        items: [{
+          href: applicationPath + "/school-experience/" + item.id + "/delete?referrer=" + referrer,
+          text: "Delete role"
+        }]
+      } if canAmend,
+      html: roleHtml
+    }) }}
+  {% endfor %}
+{% elif applicationValue(["school-experience","attained"]) == "false" %}
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    html: govukSummaryList({
       rows: [{
         key: {
           text: "Do you have any unpaid experience?"
         },
         value: {
-          text: "Yes" if applicationValue(["school-experience", "attained"]) == 'true' else 'No'
+          text: "Yes" if applicationValue(["school-experience", "attained"]) == "true" else "No"
         },
         actions: {
           items: [{
@@ -37,11 +38,6 @@
           }]
         } if canAmend
       }]
-    }) }}
-  {% endif %}
-{% endset %}
-
-{{ appSummaryCard({
-  classes: "govuk-!-margin-bottom-6",
-  html: summaryCardHtml
-}) }}
+    })
+  }) }}
+{% endif %}

--- a/app/views/_includes/item/school-experience.njk
+++ b/app/views/_includes/item/school-experience.njk
@@ -19,7 +19,7 @@
       html: roleHtml
     }) }}
   {% endfor %}
-{% elif applicationValue(["school-experience","attained"]) == "false" %}
+{% elif applicationValue(["school-experience-decision"]) == "No" %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: govukSummaryList({
@@ -28,7 +28,7 @@
           text: "Do you have any unpaid experience?"
         },
         value: {
-          text: "Yes" if applicationValue(["school-experience", "attained"]) == "true" else "No"
+          text: applicationValue(["school-experience-decision"])
         },
         actions: {
           items: [{

--- a/app/views/_includes/review/contact-details.njk
+++ b/app/views/_includes/review/contact-details.njk
@@ -1,4 +1,31 @@
-{% if applicationValue(["completed", "contact-details"]) %}
+{% set completed = applicationValue(["completed", "contact-details"]) %}
+{% set entered = applicationValue(["contact-details", "phone-number"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "contact-details",
+    title: "Contact details not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Enter your contact details",
+        href: applicationPath + "/contact-details/?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
+  {{ appSuggestion({
+    id: "contact-details",
+    title: "Contact details are not marked as completed",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Complete contact details",
+        href: applicationPath + "/contact-details/?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
+
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: govukSummaryList({
@@ -46,17 +73,5 @@
         } if canAmend
       }]
     })
-  }) }}
-{% elif showIncomplete %}
-  {{ appSuggestion({
-    id: "contact-details",
-    title: "Contact details not entered",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Enter your contact details",
-        href: applicationPath + "/contact-details/review?referrer=" + referrer
-      }]
-    }
   }) }}
 {% endif %}

--- a/app/views/_includes/review/gcse.njk
+++ b/app/views/_includes/review/gcse.njk
@@ -1,21 +1,36 @@
-{% set complete = "true" if applicationValue(["completed", id]) %}
+{% set completed = applicationValue(["completed", id]) %}
+{% set entered = applicationValue(["gcse", id, "type"]) %}
 
-{{ appSuggestion({
-  id: "gcse-" + id,
-  title: id | capitalize + " GCSE or equivalent not entered",
-  warning: true if errorList,
-  actions: {
-    items: [{
-      text: "Enter your " + id | capitalize + " GCSE or equivalent",
-      href: applicationPath + "/" + id + "/review?referrer=" + referrer
-    }]
-  }
-}) if showIncomplete and not complete }}
+{% if not entered %}
+  {{ appSuggestion({
+    id: "gcse-" + id,
+    title: id | capitalize + " GCSE or equivalent not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Enter your " + id | capitalize + " GCSE or equivalent",
+        href: applicationPath + "/gcse/" + id + "/?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
+{% else %}
+  {{ appSuggestion({
+    id: "gcse-" + id,
+    title: id | capitalize + " GCSE or equivalent not marked as complete",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Complete your " + id | capitalize + " GCSE or equivalent",
+        href: applicationPath + "/gcse/" + id + "/review?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
 
-{% set summaryCardHtml %}{% include "_includes/item/gcse.njk" %}{% endset %}
-{{ appSummaryCard({
-  classes: "govuk-!-margin-bottom-6",
-  headingLevel: 3,
-  titleText: id | capitalize + " GCSE or equivalent",
-  html: summaryCardHtml
-}) if complete }}
+  {% set summaryCardHtml %}{% include "_includes/item/gcse.njk" %}{% endset %}
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    headingLevel: 3,
+    titleText: id | capitalize + " GCSE or equivalent",
+    html: summaryCardHtml
+  }) }}
+{% endif %}

--- a/app/views/_includes/review/interview.njk
+++ b/app/views/_includes/review/interview.njk
@@ -1,4 +1,31 @@
-{% if applicationValue(["completed", "interview"]) %}
+{% set completed = applicationValue(["completed", "interview"]) %}
+{% set entered = applicationValue(["interview-choice"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "interview",
+    title: "Interview needs not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Do you have any interview needs?",
+        href: applicationPath + "/interview/?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
+  {{ appSuggestion({
+    id: "safeguarding",
+    title: "Safeguarding information not marked as complete",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Complete interview needs",
+        href: applicationPath + "/interview/review?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
+
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: govukSummaryList({
@@ -32,17 +59,5 @@
         } if canAmend
       } if applicationValue(["interview-choice"]) == "Yes"]
     })
-  }) }}
-{% elif showIncomplete %}
-  {{ appSuggestion({
-    id: "interview",
-    title: "Interview needs not entered",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Do you have any interview needs?",
-        href: applicationPath + "/interview/review?referrer=" + referrer
-      }]
-    }
   }) }}
 {% endif %}

--- a/app/views/_includes/review/personal-details.njk
+++ b/app/views/_includes/review/personal-details.njk
@@ -1,4 +1,31 @@
-{% if applicationValue(["completed", "personal-details"]) %}
+{% set completed = applicationValue(["completed", "personal-details"]) %}
+{% set entered = applicationValue(["candidate", "given-name"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "candidate",
+    title: "Personal details not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Enter your personal details",
+        href: applicationPath + "/personal-details/?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
+  {{ appSuggestion({
+    id: "candidate",
+    title: "Personal details are not marked as completed",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Complete personal details",
+        href: applicationPath + "/personal-details/review?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
+
   {% set residencyText %}
     <p class="govuk-body">{{ applicationValue(["candidate", "residency"]) }}</p>
     {% if applicationValue(["candidate", "residency-right-to-work"]) and applicationValue(["candidate", "residency"]) == "I have the right to work or study in the UK" %}
@@ -67,17 +94,5 @@
         } if canAmend
       } if applicationValue(["candidate", "residency"])]
     })
-  }) }}
-{% elif showIncomplete %}
-  {{ appSuggestion({
-    id: "candidate",
-    title: "Personal details are not marked as completed",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Enter your personal details",
-        href: applicationPath + "/personal-details/review?referrer=" + referrer
-      }]
-    }
   }) }}
 {% endif %}

--- a/app/views/_includes/review/personal-statement.njk
+++ b/app/views/_includes/review/personal-statement.njk
@@ -1,4 +1,19 @@
-{% if applicationValue(["completed", "personal-statement"]) %}
+{% set completed = applicationValue(["completed", "personal-statement"]) %}
+{% set entered = applicationValue(["personal-statement"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "personal-statement",
+    title: "Personal statement not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Why do you want to be a teacher?",
+        href: applicationPath + "/personal-statement/review?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
   {{ appSuggestion({
     title: "Proofread your personal statement",
     content: {
@@ -25,17 +40,5 @@
         } if canAmend
       }]
     })
-  }) }}
-{% elif showIncomplete %}
-  {{ appSuggestion({
-    id: "personal-statement",
-    title: "Personal statement not entered",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Why do you want to be a teacher?",
-        href: applicationPath + "/personal-statement/review?referrer=" + referrer
-      }]
-    }
   }) }}
 {% endif %}

--- a/app/views/_includes/review/reasonable-adjustments.njk
+++ b/app/views/_includes/review/reasonable-adjustments.njk
@@ -1,4 +1,31 @@
-{% if applicationValue(["completed", "reasonable-adjustments"]) %}
+{% set completed = applicationValue(["completed", "reasonable-adjustments"]) %}
+{% set entered = applicationValue(["reasonable-adjustments", "disclose"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "reasonable-adjustments",
+    title: "Any disability or other needs not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Do you want to ask for help to become a teacher?",
+        href: applicationPath + "/reasonable-adjustments/?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
+  {{ appSuggestion({
+    id: "reasonable-adjustments",
+    title: "Ask for support if you’re disabled not marked as complete",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Complete ask for support if you’re disabled",
+        href: applicationPath + "/reasonable-adjustments/review?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
+
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: govukSummaryList({
@@ -7,7 +34,7 @@
           text: "Do you need any adjustments to help you do a course or go to an interview?" if option == "b" else "Do you want to ask for help to become a teacher?"
         },
         value: {
-          text: "Yes" if applicationValue(["reasonable-adjustments", "disclose"]) == "true" else "No"
+          text: applicationValue(["reasonable-adjustments", "disclose"])
         },
         actions: {
           items: [{
@@ -30,19 +57,7 @@
             visuallyHiddenText: "your reasonable adjustments"
           }]
         } if canAmend
-      } if applicationValue(["reasonable-adjustments", "disclose"]) == 'true']
+      } if applicationValue(["reasonable-adjustments", "disclose"]) == "Yes"]
     })
-  }) }}
-{% elif showIncomplete %}
-  {{ appSuggestion({
-    id: "reasonable-adjustments",
-    title: "Any disability or other needs not entered",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Do you want to ask for help to become a teacher?",
-        href: applicationPath + "/reasonable-adjustments/review?referrer=" + referrer
-      }]
-    }
   }) }}
 {% endif %}

--- a/app/views/_includes/review/school-experience.njk
+++ b/app/views/_includes/review/school-experience.njk
@@ -1,4 +1,31 @@
-{% if applicationValue(["completed", "school-experience"]) %}
+{% set completed = applicationValue(["completed", "school-experience"]) %}
+{% set entered = applicationValue(["school-experience-decision"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "school-experience",
+    title: "Unpaid experience not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Enter your unpaid experience",
+        href: applicationPath + "/school-experience/?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
+  {{ appSuggestion({
+    id: "school-experience",
+    title: "Volunteering with children and young people is not marked as completed",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Do you have any experience working with children and young people?",
+        href: applicationPath + "/school-experience?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
+
   {{ appSuggestion({
     title: "Get school experience",
     content: {
@@ -10,19 +37,7 @@
         href: "https://schoolexperience.education.gov.uk"
       }]
     }
-  }) if applicationValue(["school-experience","attained"]) == "false" }}
+  }) if applicationValue(["school-experience-decision"]) == "No" }}
 
   {% include "_includes/item/school-experience.njk" %}
-{% elif showIncomplete %}
-  {{ appSuggestion({
-    id: "school-experience",
-    title: "Volunteering with children and young people is not marked as completed",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Do you have any experience working with children and young people?",
-        href: applicationPath + "/school-experience?referrer=" + referrer
-      }]
-    }
-  }) }}
 {% endif %}

--- a/app/views/_includes/review/subject-knowledge.njk
+++ b/app/views/_includes/review/subject-knowledge.njk
@@ -1,4 +1,31 @@
-{% if applicationValue(["completed", "subject-knowledge"]) %}
+{% set completed = applicationValue(["completed", "subject-knowledge"]) %}
+{% set entered = applicationValue(["subject-knowledge"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "subject-knowledge",
+    title: "Subject knowledge not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "What you know about the subject you want to teach?",
+        href: applicationPath + "/subject-knowledge/review?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
+  {{ appSuggestion({
+    id: "subject-knowledge",
+    title: "Subject knowledge not marked as completed",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Complete Subject knowledge",
+        href: applicationPath + "/subject-knowledge/?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
+
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: govukSummaryList({
@@ -18,17 +45,5 @@
         } if canAmend
       }]
     })
-  }) }}
-{% elif showIncomplete %}
-  {{ appSuggestion({
-    id: "subject-knowledge",
-    title: "Subject knowledge not entered",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "What you know about the subject you want to teach?",
-        href: applicationPath + "/subject-knowledge/review?referrer=" + referrer
-      }]
-    }
   }) }}
 {% endif %}

--- a/app/views/_includes/review/suitability.njk
+++ b/app/views/_includes/review/suitability.njk
@@ -1,4 +1,31 @@
-{% if applicationValue(["completed", "suitability"]) %}
+{% set completed = applicationValue(["completed", "suitability"]) %}
+{% set entered = applicationValue(["suitability", "disclose"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "safeguarding",
+    title: "Safeguarding information not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Do you need to declare any safeguarding issues?",
+        href: applicationPath + "/suitability/review?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
+  {{ appSuggestion({
+    id: "safeguarding",
+    title: "Safeguarding information not marked as complete",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Complete safeguarding issues",
+        href: applicationPath + "/suitability/review?referrer=" + referrer
+      }]
+    }
+  }) if not completed and showIncomplete }}
+
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: govukSummaryList({
@@ -7,7 +34,7 @@
           text: "Do you want to share any safeguarding issues?"
         },
         value: {
-          text: "Yes" if applicationValue(["suitability", "disclose"]) == 'true' else 'No'
+          text: applicationValue(["suitability", "disclose"])
         },
         actions: {
           items: [{
@@ -30,19 +57,7 @@
             visuallyHiddenText: "the information you are sharing"
           }]
         } if canAmend
-      } if applicationValue(["suitability", "disclose"]) == 'true']
+      } if applicationValue(["suitability", "disclose"]) == "Yes"]
     })
-  }) }}
-{% elif showIncomplete %}
-  {{ appSuggestion({
-    id: "safeguarding",
-    title: "Safeguarding information not entered",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Do you need to declare any safeguarding issues?",
-        href: applicationPath + "/suitability/review?referrer=" + referrer
-      }]
-    }
   }) }}
 {% endif %}

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -1,6 +1,19 @@
-{% if applicationValue(["completed", "work-history"]) %}
-  {% include "_includes/item/work-history.njk" %}
-{% elif showIncomplete %}
+{% set completed = applicationValue(["completed", "work-history"]) %}
+{% set entered = applicationValue(["work-history-decision"]) %}
+
+{% if not entered %}
+  {{ appSuggestion({
+    id: "work-history",
+    title: "Work history not entered",
+    warning: true if errorList,
+    actions: {
+      items: [{
+        text: "Enter your work history",
+        href: applicationPath + "/work-history/?referrer=" + referrer
+      }]
+    }
+  }) }}
+{% else %}
   {{ appSuggestion({
     id: "work-history",
     title: "Work history is not marked as completed",
@@ -8,8 +21,10 @@
     actions: {
       items: [{
         text: "Complete your work history",
-        href: applicationPath + "/work-history?referrer=" + referrer
+        href: applicationPath + "/work-history/review?referrer=" + referrer
       }]
     }
-  }) }}
+  }) if not completed and showIncomplete }}
+
+  {% include "_includes/item/work-history.njk" %}
 {% endif %}

--- a/app/views/application/choices/another.njk
+++ b/app/views/application/choices/another.njk
@@ -8,10 +8,9 @@
 {% set course = provider.courses[courseCode] %}
 
 {% block beforePageTitle %}
-  {{ appBanner({
-    html: "<h2 class=\"govuk-heading-m\">You’ve added " + course.name_and_code + " to your application</h2>",
-    type: "success",
-    icon: false
+  {{ govukNotificationBanner({
+    text: "You’ve added " + course.name_and_code + " to your application",
+    type: "success"
   }) }}
 {% endblock %}
 

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -151,17 +151,9 @@
   </section>
 
   <section class="govuk-!-margin-bottom-8">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Entry requirements</h2>
+    <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
     {{ appTaskList({
       items: [{
-        text: "Degree",
-        href: applicationPath + "/degree" + ("/review" if applicationValue(["degree"]) | length > 0 else "/add"),
-        id: "degree",
-        tag: {
-          classes: tagClass if applicationValue(["completed", "degree"]) else incompleteTagClass,
-          text: tagText if applicationValue(["completed", "degree"]) else incompleteTagText
-        }
-      }, {
         text: "English GCSE or equivalent",
         href: applicationPath + "/gcse/english" + ("/review" if applicationValue(["gcse", "english"]) | length > 0),
         id: "english-gcse",
@@ -170,6 +162,14 @@
           text: tagText if applicationValue(["completed", "english"]) else incompleteTagText
         }
       }, {
+        text: "English as a foreign language assessment",
+        href: applicationPath + "/english-language" + ("/review" if applicationValue(["english-language"]) | length > 0),
+        id: "english-language",
+        tag: {
+          classes: tagClass if applicationValue(["completed", "english-language"]) | length > 0 else incompleteTagClass,
+          text: tagText if applicationValue(["completed", "english-language"]) | length > 0 else incompleteTagText
+        }
+      } if international, {
         text: "Maths GCSE or equivalent",
         href: applicationPath + "/gcse/maths" + ("/review" if applicationValue(["gcse", "maths"]) | length > 0),
         id: "maths-gcse",
@@ -186,14 +186,22 @@
           text: tagText if applicationValue(["completed", "science"]) else incompleteTagText
         }
       } if hasPrimaryChoices() or applicationValue(["gcse", "science"]), {
-        text: "English as a foreign language assessment",
-        href: applicationPath + "/english-language" + ("/review" if applicationValue(["english-language"]) | length > 0),
-        id: "english-language",
+        text: "Other qualifications" if international else "A levels and other qualifications",
+        href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["other-qualifications"]) | length > 0 else "/add"),
+        id: "other-qualifications",
         tag: {
-          classes: tagClass if applicationValue(["completed", "english-language"]) | length > 0 else incompleteTagClass,
-          text: tagText if applicationValue(["completed", "english-language"]) | length > 0 else incompleteTagText
+          classes: tagClass if applicationValue(["completed", "other-qualifications"]) | length > 0 else incompleteTagClass,
+          text: tagText if applicationValue(["completed", "other-qualifications"]) | length > 0 else incompleteTagText
         }
-      } if international]
+      }, {
+        text: "Degree",
+        href: applicationPath + "/degree" + ("/review" if applicationValue(["degree"]) | length > 0 else "/add"),
+        id: "degree",
+        tag: {
+          classes: tagClass if applicationValue(["completed", "degree"]) else incompleteTagClass,
+          text: tagText if applicationValue(["completed", "degree"]) else incompleteTagText
+        }
+      }]
     }) }}
   </section>
 
@@ -245,15 +253,6 @@
         tag: {
           classes: tagClass if applicationValue(["completed", "subject-knowledge"]) | length > 0 else incompleteTagClass,
           text: tagText if applicationValue(["completed", "subject-knowledge"]) | length > 0 else incompleteTagText
-        }
-      }, {
-        text: "Other qualifications",
-        hint: "For example, A level, AS level, GCSE, Diploma",
-        href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["other-qualifications"]) | length > 0 else "/add"),
-        id: "other-qualifications",
-        tag: {
-          classes: tagClass if applicationValue(["completed", "other-qualifications"]) | length > 0 else incompleteTagClass,
-          text: tagText if applicationValue(["completed", "other-qualifications"]) | length > 0 else incompleteTagText
         }
       }]
     }) }}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -236,7 +236,7 @@
   </section>
 
   <section class="govuk-!-margin-bottom-8">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and subject knowledge</h2>
+    <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement</h2>
     {{ appTaskList({
       items: [{
         text: "Why you want to teach",

--- a/app/views/application/other-qualifications/details.njk
+++ b/app/views/application/other-qualifications/details.njk
@@ -6,7 +6,6 @@
   or type | replace("qualification", "") | replace("Other UK", "UK") | replace("Non", "non")
 %}
 {% set international = type == "Non-UK qualification" %}
-{% set parent = "Other qualifications" %}
 {% set action = "edit" if applicationValue(["other-qualifications", id, "subject"]) else "add" %}
 {% set title = (action | capitalize) + " " + qualificationName + " qualification" %}
 {% set allowsFeedback = true %}

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -1,7 +1,8 @@
 {% extends "_form.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
-{% set title = "Other qualifications" %}
+{% set international = applicationValue(["candidate", "other-nationality-1"]) %}
+{% set title = "Other qualifications" if international else "A levels and other qualifications" %}
 {% set allowsFeedback = true %}
 
 {% block pageNavigation %}

--- a/app/views/application/other-qualifications/review.njk
+++ b/app/views/application/other-qualifications/review.njk
@@ -2,7 +2,8 @@
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set formaction = applicationPath %}
-{% set title = "Other qualifications" %}
+{% set international = applicationValue(["candidate", "other-nationality-1"]) %}
+{% set title = "Other qualifications" if international else "A levels and other qualifications" %}
 {% set allowsFeedback = true %}
 {% set referrer = applicationPath + "/other-qualifications/review" %}
 {% set canAmend = true %}

--- a/app/views/application/reasonable-adjustments/index.njk
+++ b/app/views/application/reasonable-adjustments/index.njk
@@ -16,62 +16,61 @@
 {% endblock %}
 
 {% block primary %}
+  {% set disabilityConditional %}
+    {{ govukCharacterCount({
+      label: {
+        html: "Give any relevant information",
+        classes: "govuk-label--s"
+      },
+      maxwords: 400,
+      rows: 8
+    } | decorateApplicationAttributes(["reasonable-adjustments", "statement"])) }}
+  {% endset %}
 
-{% set disabilityConditional %}
-  {{ govukCharacterCount({
-    label: {
-      html: "Give any relevant information",
-      classes: "govuk-label--s"
+  <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
+  <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
+  <p class="govuk-body">Examples of support could be:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>organising equipment like a hearing loop or an adapted keyboard</li>
+    <li>putting you in touch with support staff if you have a mental health condition</li>
+    <li>making sure classrooms are wheelchair accessible</li>
+  </ul>
+  <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
+
+  <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
+  <p class="govuk-body">If you’re disabled, <a href="https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability">it’s against the law to discriminate against you</a>. Training providers must not:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
+    <li>reject your application because you’re disabled</li>
+  </ul>
+
+  {{ govukRadios({
+    fieldset: {
+      classes: "govuk-!-margin-top-6",
+      legend: {
+        text: "Do you want to ask for help to become a teacher?",
+        classes: "govuk-fieldset__legend--m"
+      }
     },
+    items: [{
+      value: "Yes",
+      text: "Yes, I want to share information about myself so my provider can take steps to support me",
+      conditional: {
+        html: disabilityConditional
+      }
+    }, {
+      value: "No",
+      text: "No"
+    }]
+  } | decorateApplicationAttributes(["reasonable-adjustments", "disclose"])) }}
 
-    maxwords: 400,
-    rows: 8
-  } | decorateApplicationAttributes(["reasonable-adjustments", "statement"])) }}
-{% endset %}
+  {{ govukInput({
+    name: "option",
+    type: "hidden",
+    value: option
+  }) }}
 
-<p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
-<p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
-<p class="govuk-body">Examples of support could be:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>organising equipment like a hearing loop or an adapted keyboard</li>
-  <li>putting you in touch with support staff if you have a mental health condition</li>
-  <li>making sure classrooms are wheelchair accessible</li>
-</ul>
-<p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
-
-<h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
-<p class="govuk-body">If you’re disabled, <a href="https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability">it’s against the law to discriminate against you</a>. Training providers must not:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
-  <li>reject your application because you’re disabled</li>
-</ul>
-
-{{ govukRadios({
-  fieldset: {
-    classes: "govuk-!-margin-top-6",
-    legend: {
-      text: "Do you want to ask for help to become a teacher?",
-      classes: "govuk-fieldset__legend--m"
-    }
-  },
-  items: [{
-    value: "true",
-    text: "Yes, I want to share information about myself so my provider can take steps to support me",
-    conditional: {
-      html: disabilityConditional
-    }
-  }, {
-    value: "false",
-    text: "No"
-  }]
-} | decorateApplicationAttributes(["reasonable-adjustments", "disclose"])) }}
-
-{{ govukInput({
-  name: "option",
-  type: "hidden",
-  value: option
-}) }}
-{{ govukButton({
-  text: "Continue"
-}) }}
+  {{ govukButton({
+    text: "Continue"
+  }) }}
 {% endblock %}

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -94,7 +94,7 @@
   </section>
 
   <section class="app-section">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and subject knowledge</h2>
+    <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement</h2>
 
     <h3 class="govuk-heading-m">Why you want to teach</h3>
     {% include "_includes/review/personal-statement.njk" %}

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -58,14 +58,15 @@
   </section>
 
   <section class="app-section">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Entry requirements</h2>
-
-    <h3 class="govuk-heading-m">Degree</h3>
-    {% include "_includes/review/degrees.njk" %}
+    <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 
     <h3 class="govuk-heading-m">GCSEs or equivalent</h3>
     {% set id = "english" %}
     {% include "_includes/review/gcse.njk" %}
+
+    {% if international %}
+      {% include "_includes/review/english-language.njk" %}
+    {% endif %}
 
     {% set id = "maths" %}
     {% include "_includes/review/gcse.njk" %}
@@ -75,9 +76,11 @@
       {% include "_includes/review/gcse.njk" %}
     {% endif %}
 
-    {% if international %}
-      {% include "_includes/review/english-language.njk" %}
-    {% endif %}
+    <h3 class="govuk-heading-m">{{ "Other qualifications" if international else "A levels and other qualifications" }}</h3>
+    {% include "_includes/review/other-qualifications.njk" %}
+
+    <h3 class="govuk-heading-m">Degree</h3>
+    {% include "_includes/review/degrees.njk" %}
   </section>
 
   <section class="app-section">
@@ -98,9 +101,6 @@
 
     <h3 class="govuk-heading-m">Your suitability to teach a subject or age group</h3>
     {% include "_includes/review/subject-knowledge.njk" %}
-
-    <h3 class="govuk-heading-m">Other qualifications</h3>
-    {% include "_includes/review/other-qualifications.njk" %}
   </section>
 
   <section class="app-section">

--- a/app/views/application/school-experience/index.njk
+++ b/app/views/application/school-experience/index.njk
@@ -35,13 +35,13 @@
       }
     },
     items: [{
-      value: "true",
+      value: "Yes",
       text: "Yes"
     }, {
-      value: "false",
+      value: "No",
       text: "No"
     }]
-  } | decorateApplicationAttributes(["school-experience", "attained"])) }}
+  } | decorateApplicationAttributes(["school-experience-decision"])) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/school-experience/review.njk
+++ b/app/views/application/school-experience/review.njk
@@ -20,7 +20,7 @@
     text: addButtonText,
     href: applicationPath + "/school-experience/add/role?referrer=" + referrer,
     classes: "govuk-button--secondary"
-  }) if applicationValue(["school-experience", "attained"]) != "false" }}
+  }) if applicationValue(["school-experience-decision"]) != "No" }}
 
   {% include "_includes/review/school-experience.njk" %}
 

--- a/app/views/application/school-experience/role.njk
+++ b/app/views/application/school-experience/role.njk
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Don’t include paid work in a school – enter these roles in ‘Work history’.</p>
+  <p class="govuk-body">Do not include paid work in a school – enter these roles in ‘Work history’.</p>
   {{ govukInput({
     label: {
       text: "Your role",
@@ -36,11 +36,10 @@
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "Did this job involve working in a school or with children?",
+        text: "Did this role involve working in a school or with children?",
         classes: "govuk-fieldset__legend--m"
       }
     },
-    classes: "govuk-radios--inline",
     items: [{
       text: "Yes"
     }, {
@@ -48,19 +47,17 @@
     }]
   } | decorateApplicationAttributes(["school-experience", id, "worked-with-children"])) }}
 
-  <h2 class="govuk-heading-m">How long have you been in this role and what does it involve?</h2>
   {% set startDate = applicationValue(["school-experience", id, "start-date"]) %}
   {% set endDate = applicationValue(["school-experience", id, "end-date"]) %}
-
   {{ govukDateInput({
     fieldset: {
       legend: {
-        text: "Start date",
-        classes: "govuk-fieldset__legend--s"
+        text: "When did you start this role?",
+        classes: "govuk-fieldset__legend--m"
       }
     },
     hint: {
-      text: "For example, 3 2018"
+      text: "For example, 5 2018. If you cannot remember the exact month or year, enter an estimate."
     },
     namePrefix: id + "-start-date",
     items: [{
@@ -76,63 +73,73 @@
     }]
   } | decorateApplicationAttributes(["school-experience", id, "start-date"])) }}
 
-  {{ govukDateInput({
+  {{ govukCheckboxes({
+    items: [{
+      value: "true",
+      text: "I’m not sure the exact month or year I started"
+    }]
+  } | decorateApplicationAttributes(["school-experience", id, "start-date-is-exact"])) }}
+
+  {% set endDateHtml %}
+    {{ govukDateInput({
+      fieldset: {
+        legend: {
+          text: "When did you finish this role?",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: "For example, 5 2018. If you cannot remember the exact month or year, enter an estimate."
+      },
+      namePrefix: id + "-end-date",
+      items: [{
+        label: "Month",
+        name: "month",
+        value: endDate | date("L"),
+        classes: "govuk-input--width-2"
+      }, {
+        label: "Year",
+        name: "year",
+        value: endDate | date("yyyy"),
+        classes: "govuk-input--width-4"
+      }]
+    } | decorateApplicationAttributes(["school-experience", id, "end-date"])) }}
+
+    {{ govukCheckboxes({
+      items: [{
+        value: "true",
+        text: "I’m not sure the exact month or year I left"
+      }]
+    } | decorateApplicationAttributes(["school-experience", id, "end-date-is-exact"])) }}
+  {% endset %}
+
+  {{ govukRadios({
     fieldset: {
       legend: {
-        text: "End date (leave blank if this is your current role)",
-        classes: "govuk-fieldset__legend--s"
+        text: "Are you still working in this role?",
+        classes: "govuk-fieldset__legend--m"
       }
     },
-    hint: {
-      text: "For example, 3 2019"
-    },
-    namePrefix: id + "-end-date",
     items: [{
-      label: "Month",
-      name: "month",
-      value: endDate | date("L"),
-      classes: "govuk-input--width-2"
+      text: "Yes"
     }, {
-      label: "Year",
-      name: "year",
-      value: endDate | date("yyyy"),
-      classes: "govuk-input--width-4"
+      text: "No",
+      conditional: {
+        html: endDateHtml
+      }
     }]
   } | decorateApplicationAttributes(["school-experience", id, "end-date"])) }}
 
   {{ govukCharacterCount({
     label: {
       text: "Enter details of your time commitment and responsibilities",
-      classes: "govuk-label--s"
+      classes: "govuk-label--m"
     },
     hint: {
       text: "For example, ‘I volunteer in the classroom every Friday morning’ or ‘I spent 1 day observing in this school’ or ‘I am a Scout Leader involved in activities throughout the year’"
     },
     maxwords: 150
   } | decorateApplicationAttributes(["school-experience", id, "time-commitment"])) }}
-
-  {# Only ask if want to add another if:
-    * not editing an existing item
-    * not referred from a review page (which has an ‘Add another…’ button)
-  #}
-  {% if action != "edit" and not referrer %}
-    {{ govukRadios({
-      name: "next",
-      fieldset: {
-        legend: {
-          text: "Do you want to add another role?",
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [{
-        value: "add",
-        text: "Yes"
-      }, {
-        value: "review",
-        text: "No"
-      }]
-    }) }}
-  {% endif %}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/suitability/index.njk
+++ b/app/views/application/suitability/index.njk
@@ -50,7 +50,7 @@
     }
   },
   items: [{
-    value: "true",
+    value: "Yes",
     text: "Yes, I want to share something",
     hint: {
       text: "After you have submitted your application, your provider may be in touch to discuss the information you shared. If you prefer, you can contact your provider directly."
@@ -59,7 +59,7 @@
       html: disabilityConditional
     }
   }, {
-    value: "false",
+    value: "No",
     text: "No"
   }]
 } | decorateApplicationAttributes(["suitability", "disclose"])) }}


### PR DESCRIPTION
On making first pass at flight check fixes, broke how section and application review pages appear in different states.

This PR fixes these issues by determining if a section has been entered (some or all fields have values) and completed (section marked as completed). When we come to iteration 2 of flight check, some of this logic may change or go away, so this is an interim solution to make it so that the application works properly again. Hopefully.

This PR also reverts some of the section ordering and changes made for interaction 1 of A levels fixes, and uses the new section ordering instead:

* English GCSE or equivalent
* [English as a foreign language assessment]
* Maths GCSE or equivalent
* [Science GCSE or equivalent]
* A levels and other qualifications
* Degree

A separate PR will look to make the additional A-level changes, such that you can complete the other qualifications section by saying you don’t want to add any qualifications.