### PR TITLE
Add feedback variants for research

### DIFF
--- a/app/data/application.js
+++ b/app/data/application.js
@@ -25,8 +25,8 @@ module.exports = {
   },
   choices: {
     ABCDE: {
-      courseCode: '2XT2',
-      providerCode: '1N1',
+      courseCode: '2MH9',
+      providerCode: '1DR',
       locationName: 'Hillcrest Academy',
       locationAddress: 'Cowper Street, Leeds. LS7 4DR',
       studyMode: 'Full time',
@@ -36,8 +36,8 @@ module.exports = {
       status: 'Awaiting decision'
     },
     FGHIJ: {
-      courseCode: '2VLT',
-      providerCode: 'L24',
+      courseCode: '38PN',
+      providerCode: 'S90',
       locationName: 'Main Site',
       locationAddress: 'Brownberrie Lane, Horsforth, Leeds. LS18 5HD',
       studyMode: 'Full time',
@@ -47,8 +47,8 @@ module.exports = {
       status: 'Awaiting decision'
     },
     ZYXWV: {
-      courseCode: 'X100',
-      providerCode: 'B60',
+      courseCode: 'AP21',
+      providerCode: '4F5',
       locationName: 'Main Site',
       locationAddress: 'David Hockney Building, Great Horton Road, Bradford. BD7 1AY',
       studyMode: 'Full time',

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -298,10 +298,14 @@ module.exports = router => {
         choices.ZYXWV.status = 'Awaiting decision'
         break
 
+      // Actionable feedback
       case 'ended-without-success':
         choices.ABCDE.status = 'Unsuccessful'
         choices.ABCDE.feedback = {
-          performanceAtInterview: "You did not show sufficient depth within your responses during the Interview. This was most evident when you were asked about what it means to be a primary teacher.<br><br>You demonstrated a lack of critical evaluation within presentation and research questions.<br><br>The detail we are looking for is outlined in our selection criteria, which can be found attached to the interview invitation letter. For future applications, you could improve by ensuring you are able to cover and evidence the selection criteria."
+          qualityOfApplication: {
+            personalStatement: "Contained several spelling mistakes and grammatical errors.\n\nThe candidate should describe the impact they want to have on their students in more detail.",
+            other: "Candidate was not able to demonstrate sufficient experience of working with children."
+          }
         }
         choices.FGHIJ.status = 'Unsuccessful'
         choices.FGHIJ.feedback = {
@@ -313,7 +317,64 @@ module.exports = router => {
         choices.ZYXWV.status = 'Unsuccessful'
         choices.ZYXWV.interview = null
         choices.ZYXWV.feedback = {
-          additionalFeedback: "Thank you for your application. After careful consideration, we have decided not to select you for interview for a place on this highly competitive programme.  We wish you all the best with the other applications you have made."
+          qualityOfApplication: {
+            personalStatement: "Focus more on why teaching is the career for you.",
+            subjectKnowledge: "Look at ways to evidence subject knowledge within your application or supporting statement."
+          }
+        }
+        break
+
+      // Vague feedback
+      case 'ended-without-success-vague-feedback':
+        choices.ABCDE.status = 'Unsuccessful'
+        choices.ABCDE.feedback = {
+          qualityOfApplication: {
+            personalStatement: "The overall application was weak suggesting that the applicant may not be successful on the course",
+            subjectKnowledge: "Lack of reference regarding the subject."
+          }
+        }
+        choices.FGHIJ.status = 'Unsuccessful'
+        choices.FGHIJ.feedback = {
+          performanceAtInterview: "You had not made a sufficiently considered and informed decision to train to teach.",
+          qualityOfApplication: {
+            personalStatement: "The quality of communication in the personal statement could be improved."
+          },
+          additionalFeedback: "There have been limited places for this course and stronger applications received."
+        }
+        choices.ZYXWV.status = 'Unsuccessful'
+        choices.ZYXWV.interview = null
+        choices.ZYXWV.feedback = {
+          qualityOfApplication: {
+            personalStatement: "Focus more on why teaching is the career for you.",
+            subjectKnowledge: "Academic record does not look strong enough to cope with the PGCE that is mandatory this year, on top of heavy planning and teaching workload."
+          },
+          additionalFeedback: "You could apply for the unsalaried route that we offer."
+        }
+        break
+
+      // Qualifications feedback
+      case 'ended-without-success-qualifications-feedback':
+        choices.ABCDE.status = 'Unsuccessful'
+        choices.ABCDE.feedback = {
+          qualifications: {
+            noMathsGCSEOrEquivalent: true
+          }
+        }
+        choices.FGHIJ.status = 'Unsuccessful'
+        choices.FGHIJ.feedback = {
+          qualifications: {
+            noMathsGCSEOrEquivalent: true,
+            other: "Our minimum degree requirement is a 2:1. We cannot accepted degrees with a 2:2 or below."
+          },
+          additionalFeedback: "There have been limited places for this course and stronger applications received."
+        }
+        choices.ZYXWV.status = 'Unsuccessful'
+        choices.ZYXWV.interview = null
+        choices.ZYXWV.feedback = {
+          qualifications: {
+            noMathsGCSEOrEquivalent: true,
+            other: "Thank you for your application. Unfortunately you do not meet our entry requirements in terms of subject knowledge. As your degree is not in English you would need A Levels of grade C or above in English Language and English Literature."
+          }
         }
         break
 

--- a/app/views/_includes/item/feedback.njk
+++ b/app/views/_includes/item/feedback.njk
@@ -39,29 +39,63 @@
 {% if item.feedback.qualityOfApplication %}
 <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Quality of application</h4>
 
-{% if item.feedback.qualityOfApplication.personalStatement %}
-  <p class="govuk-body">Personal statement could be improved.</p>
-  {{ govukInsetText({
-    classes: "app-inset-text--narrow-border govuk-!-margin-top-0",
-    text: item.feedback.qualityOfApplication.personalStatement | nl2br | safe
-  }) }}
-{% endif %}
+  {% set qualityOfApplicaitonFeedback %}
+    {% if item.feedback.qualityOfApplication.personalStatement %}
+      <p class="govuk-body govuk-!-margin-bottom-0">Personal statement could be improved.</p>
+      <p class="govuk-body">{{ item.feedback.qualityOfApplication.personalStatement | nl2br | safe }}</p>
+    {% endif %}
 
-{% if item.feedback.qualityOfApplication.subjectKnowledge %}
-  <p class="govuk-body">Subject knowledge could be improved.</p>
+    {% if item.feedback.qualityOfApplication.subjectKnowledge %}
+      <p class="govuk-body govuk-!-margin-bottom-0">Subject knowledge could be improved.</p>
+      <p class="govuk-body">{{ item.feedback.qualityOfApplication.subjectKnowledge | nl2br | safe }}</p>
+    {% endif %}
+
+    {% if item.feedback.qualityOfApplication.other %}
+      <p class="govuk-body">{{ item.feedback.qualityOfApplication.other | nl2br | safe }} </p>
+    {% endif %}
+  {% endset %}
+
   {{ govukInsetText({
     classes: "app-inset-text--narrow-border govuk-!-margin-top-0",
-    text: item.feedback.qualityOfApplication.subjectKnowledge | nl2br | safe
+    html: qualityOfApplicaitonFeedback
   }) }}
-{% endif %}
 {% endif %}
 
 {% if item.feedback.qualifications %}
-<h4 class="govuk-heading-s govuk-!-margin-bottom-2">Qualifications</h4>
+  <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Qualifications</h4>
 
-{% if item.feedback.qualifications.degree_does_not_meet_requirements %}
-  <p class="govuk-body">Your degree does not meet the course requirements.</p>
-{% endif %}
+  {% set qualificationsFeedbackHtml %}
+
+    {% if item.feedback.qualifications.noMathsGCSEOrEquivalent %}
+      <p class="govuk-body">No maths GCSE grade 4 (C) or above, or accepted equivalent.</p>
+    {% endif %}
+
+    {% if item.feedback.qualifications.noEnglishGCSEOrEquivalent %}
+      <p class="govuk-body">No English GCSE grade 4 (C) or above, or accepted equivalent.</p>
+    {% endif %}
+
+    {% if item.feedback.qualifications.noScienceGCSEOrEquivalent %}
+      <p class="govuk-body">No science GCSE grade 4 (C) or above, or accepted equivalent (for primary applicants).</p>
+    {% endif %}
+
+    {% if item.feedback.qualifications.noDegree %}
+      <p class="govuk-body">No degree.</p>
+    {% endif %}
+
+    {% if item.feedback.qualifications.degree_does_not_meet_requirements %}
+      <p class="govuk-body">Degree does not meet course requirements.</p>
+    {% endif %}
+
+    {% if item.feedback.qualifications.other %}
+      <p class="govuk-body">{{ item.feedback.qualifications.other | nl2br }}</p>
+    {% endif %}
+  {% endset %}
+
+  {{ govukInsetText({
+    classes: "app-inset-text--narrow-border govuk-!-margin-top-0",
+    html: qualificationsFeedbackHtml | safe
+  }) }}
+
 {% endif %}
 
 {% if item.feedback.additionalFeedback %}

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -84,8 +84,15 @@
     <dt><a href="/dashboard/12345/received-two-offers">Received two offers</a></dt>
     <dd>All providers have responded and two offers have been made</dd>
 
-    <dt><a href="/dashboard/12345/ended-without-success">Ended without success</a></dt>
-    <dd>All of the candidate’s applications have been withdrawn, rejected, declined or offer conditions were not met.</dd>
+    <dt><a href="/dashboard/12345/ended-without-success">Ended without success (actionable feedback)</a></dt>
+    <dd>All of the candidate’s applications were unsuccessful, but they were given clear, actionable feedback.</dd>
+
+    <dt><a href="/dashboard/12345/ended-without-success-vague-feedback">Ended without success (vague feedback)</a></dt>
+    <dd>All of the candidate’s applications were unsuccessful, but the feedback was vague.</dd>
+
+    <dt><a href="/dashboard/12345/ended-without-success-qualifications-feedback">Ended without success (feedback suggests did not meet entry criteria)</a></dt>
+    <dd>All of the candidate’s applications were unsuccessful, and the feedback suggests it was because the entry criteria was not met.</dd>
+
     <dt><a href="/dashboard/12345/pending-conditions">Accepted offer, pending conditions</a></dt>
     <dd>The candidate has accepted an offer. The provider now has to confirm to us that the candidate has met the conditions in the offer.</dd>
     <dt><a href="/dashboard/12345/offer-deferred">Offer deferred</a></dt>


### PR DESCRIPTION
This adds some more examples of feedback given for unsuccessful applications, for use in research.

Examples included:

1. Actionable feedback - ie things that can be immediately fixed by rewriting personal statement and subject knowledge sections.
2. Vague feedback - fairly generic feedback which doesn't offer any specific advice, but is still tied to certain sections.
3. Qualifications feedback - feedback that the qualifications (Maths GCSE and degree) were insufficient.