### PR TITLE
Add guidance on how many courses you can select for apply again

### DIFF
--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -80,6 +80,7 @@
   <section class="govuk-!-margin-bottom-8">
     {% if apply2 %}
       <h2 class="govuk-heading-m govuk-!-font-size-27">Course</h2>
+      <p class="govuk-body">You can apply to 1 course at a time at this stage of your application.</p>
     {% else %}
       <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
       {% if closed == "true" %}


### PR DESCRIPTION
This adds some guidance on course selection to the application page, as it is not always read on the Choose your course page.

<img width="678" alt="Screenshot 2021-03-22 at 13 53 03" src="https://user-images.githubusercontent.com/30665/112002837-38010900-8b18-11eb-8866-e60177a86c61.png">
