### PR TITLE
Add teacher training adviser reference

### DIFF
--- a/app/views/application/decision/view.njk
+++ b/app/views/application/decision/view.njk
@@ -1,6 +1,5 @@
 {% extends "_form.njk" %}
 
-{% set parent = provider.name + " - " + course.name_and_code %}
 {% set title = "Details of offer" %}
 {% set referrer = "/application/" + applicationId + "/" + choiceId + "/view" %}
 

--- a/app/views/application/decision/view.njk
+++ b/app/views/application/decision/view.njk
@@ -23,6 +23,8 @@
     <li>if you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year</li>
   </ul>
 
+  <p class="govuk-body">If you need help, you can speak to our <a href="https://beta-adviser-getintoteaching.education.gov.uk" class="govuk-link">teacher training advisers</a>.</p>
+
   {{ govukRadios({
     fieldset: {
       classes: "govuk-!-margin-top-6",


### PR DESCRIPTION
Two small changes:

* Add a paragraph back in with a link to the teacher training adviser service.
* Remove caption before the h1 (this was already done in production, but not in the prototype)

## Screenshot

![localhost_3000_application_12345_ABCDE_view](https://user-images.githubusercontent.com/30665/112304604-943d6780-8c95-11eb-8514-20b7995b2a41.png)
