### PR TITLE
Add survey to post-submission flow

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -32,6 +32,7 @@ require('./routes/application')(router)
 require('./routes/reference')(router)
 require('./routes/emails')(router)
 require('./routes/send-email')(router)
+require('./routes/survey')(router)
 
 // Clear all data in session if you open /admin/clear-data
 router.post('/admin/clear-data', function (req, res) {

--- a/app/routes/send-email.js
+++ b/app/routes/send-email.js
@@ -69,7 +69,7 @@ module.exports = router => {
       amendDate: utils.nowPlusDays(7, 'd MMMM yyyy')
     })
 
-    res.redirect(`/dashboard/${applicationId}?confirmation=true`)
+    res.redirect(`/survey?applicationId=${applicationId}`)
   })
 
   // Decision: Unsuccessful/Offer received

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -1,0 +1,15 @@
+module.exports = router => {
+  router.get('/survey', (req, res) => {
+    const { applicationId } = req.query
+
+    res.render(`survey/index`, {
+      applicationId
+    })
+  })
+
+  router.post('/survey', (req, res) => {
+    const { applicationId } = req.body
+
+    res.redirect(`/dashboard/${applicationId}?confirmation=true`)
+  })
+}

--- a/app/views/survey/index.njk
+++ b/app/views/survey/index.njk
@@ -1,9 +1,12 @@
 {% extends "_form.njk" %}
 
 {% set title = "Your feedback" %}
-{% set formaction = "/survey/thank-you" %}
+{% set formaction = "/survey" %}
 
 {% block primary %}
+
+  <input type="hidden" name="applicationId" value="{{ applicationId }}" />
+
   {{ govukRadios({
     fieldset: {
       legend: {
@@ -23,7 +26,7 @@
   {{ govukCharacterCount({
     label: {
       classes: "govuk-label--m",
-      text: "How could we improve this service?"
+      text: "How could we improve this service? (optional)"
     },
     maxwords: 1200,
     rows: 6


### PR DESCRIPTION
This is an alternative to #484, and adds the survey to the post-submission flow, just before taking the user to the application dashboard showing the confirmation banner. To make it a clearer that the free-text is optional, "(optional)" is added to the label.

➡️  [Review this journey](https://apply-beta-p-add-survey-jveeye.herokuapp.com/application/12345)

### Screenshots

<img width="691" alt="Screenshot 2021-03-25 at 11 57 55" src="https://user-images.githubusercontent.com/30665/112469413-5e65b500-8d61-11eb-9365-d2453615f8c0.png">

