### PR TITLE
Only show interviews information when awaiting decision

### DIFF
--- a/app/views/dashboard/_course-choices.njk
+++ b/app/views/dashboard/_course-choices.njk
@@ -108,7 +108,7 @@
         value: {
           html: interviewHtml | safe
         }
-      } if not canRespond and item.status != "Unsuccessful", {
+      } if item.status == "Awaiting decision", {
         key: {
           text: "Feedback"
         },


### PR DESCRIPTION
We don't need to show the interview information on the dashboard when a course has been offered, accepted, withdrawn or unsuccessful.