### PR TITLE
Change "Conditions met" to "Offer confirmed"

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -237,7 +237,7 @@ module.exports = (env) => {
       case 'Offer withdrawn':
       case 'Conditions not met':
         return `${prefix}--red`
-      case 'Conditions met':
+      case 'Offer confirmed':
         return `${prefix}--green`
       case 'Unsuccessful':
       case 'Application not sent':

--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -174,7 +174,7 @@ module.exports = router => {
         ]
         break
       case 'recruited-single':
-        choices.ABCDE.status = 'Conditions met'
+        choices.ABCDE.status = 'Offer confirmed'
         choices.ABCDE.rejectedByDefault = false
         break
 
@@ -395,7 +395,7 @@ module.exports = router => {
         break
 
       case 'recruited':
-        choices.ZYXWV.status = 'Conditions met'
+        choices.ZYXWV.status = 'Offer confirmed'
         application.choices = [choices.ZYXWV]
         break
 
@@ -425,7 +425,7 @@ module.exports = router => {
     }).length
 
     const courseOfferAccepted = utils.toArray(application.choices).filter(function (choice) {
-      return (choice.status === 'Offer accepted') || (choice.status === 'Conditions met') || (choice.status === 'Offer deferred')
+      return (choice.status === 'Offer accepted') || (choice.status === 'Offer confirmed') || (choice.status === 'Offer deferred')
     }).length > 0
 
     const canMakeDecision = (numberOfOffersReceived > 0 && numberOfChoicesAwaitingDecision === 0)

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -8,7 +8,7 @@
   }) }}
   {% if status == "Offer deferred" %}
     <p class="govuk-body govuk-body govuk-!-margin-top-2">Your training will now start in September 2021.</p>
-  {% elif status == "Offer received" or status == "Offer accepted" or status == "Conditions met" %}
+  {% elif status == "Offer received" or status == "Offer accepted" or status == "Offer confirmed" %}
     {{ govukDetails({
       classes: "govuk-!-margin-bottom-0 govuk-!-margin-top-2",
       summaryText: "What to do if you’re unable to start training in " + startDate,

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -11,7 +11,7 @@
 
     {% set hasResponded =
       (item.status == "Conditions not met")
-      or (item.status == "Conditions met")
+      or (item.status == "Offer confirmed")
       or (item.status == "Offer declined")
       or (item.status == "Unsuccessful")
       or (item.status == "Offer withdrawn")

--- a/app/views/dashboard/_course-choices.njk
+++ b/app/views/dashboard/_course-choices.njk
@@ -3,7 +3,7 @@
 
   {% set hasResponded =
     (item.status == "Conditions not met")
-    or (item.status == "Conditions met")
+    or (item.status == "Offer confirmed")
     or (item.status == "Offer declined")
     or (item.status == "Unsuccessful")
     or (item.status == "Offer withdrawn")

--- a/app/views/dashboard/_guidance.njk
+++ b/app/views/dashboard/_guidance.njk
@@ -25,7 +25,7 @@
   <p class="govuk-body">You’ve chosen to defer your course.</p>
   <p class="govuk-body">Before your offer is confirmed, there are some final conditions to meet.</p>
 
-{% elif choices | length == 1 and choices[0].status == "Conditions met" %}
+{% elif choices | length == 1 and choices[0].status == "Offer confirmed" %}
 
   <p class="govuk-body">Congratulations on joining your teacher training course.</p>
 


### PR DESCRIPTION
Currently we display "Conditions met" as the status for courses where the provider has confirmed that the candidate has met all the conditions required for the course.

However, some courses don’t have any conditions at all, or at least any conditions specified on the service (there might be some administrative conditions off-service). In these scenarios, the status doesn’t make sense.

Whilst we _could_ have a different status label for those who have accepted unconditional offers only, it would be simpler if we could find a new label that works in all scenarios.

"Offer confirmed" is potentially a more positive-sounding label than "Conditions met", and is also consistent with the language used on the service when the candidate has not yet met the conditions, which states:

> You’ve accepted the offer from [provider name]
>
> Before your offer is confirmed, there are some final conditions to meet.

Note: before January 2020, we were displaying "Recruited" in this state, but this [was changed to Conditions met](https://github.com/DFE-Digital/apply-for-teacher-training/pull/1010). Reverting back to "Recruited" could be an option, but perhaps this is a bit jargon-y, and more of a provider-facing term?

## Screenshots

### Before

<img width="725" alt="Screenshot 2021-03-25 at 13 22 16" src="https://user-images.githubusercontent.com/30665/112480913-64ae5e00-8d6e-11eb-9e31-fb118002aed0.png">

### After

<img width="734" alt="Screenshot 2021-03-25 at 13 22 05" src="https://user-images.githubusercontent.com/30665/112480943-6d069900-8d6e-11eb-9121-6beb68bae40f.png">

### Pending conditions state (for context)

<img width="760" alt="Screenshot 2021-03-25 at 13 22 28" src="https://user-images.githubusercontent.com/30665/112481007-7abc1e80-8d6e-11eb-9faa-814e8b62df61.png">
