### PR TITLE
Add section break classes

### DIFF
--- a/app/views/dashboard/_previous-applications.njk
+++ b/app/views/dashboard/_previous-applications.njk
@@ -36,7 +36,7 @@
 
     {% endfor %}
 
-  <hr>
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   {% endfor %}
 
   {{ govukTable({


### PR DESCRIPTION
These help push the Previous applications section further away from the rest of the content, as they're likely a lot less important.

<img width="749" alt="Screenshot 2021-03-26 at 10 55 33" src="https://user-images.githubusercontent.com/30665/112621550-cbd91a80-8e21-11eb-8e70-0382001811e6.png">
