### PR TITLE
Use standard inset text and headings

### DIFF
--- a/app/assets/sass/components/_inset-text.scss
+++ b/app/assets/sass/components/_inset-text.scss
@@ -18,12 +18,3 @@
     color: $govuk-error-colour;
   }
 }
-
-.app-inset-text--review {
-  border-color: govuk-tint(govuk-colour("pink"), 40);
-
-  .govuk-heading-s {
-    color: govuk-shade(govuk-colour("pink"), 40);
-  }
-
-}

--- a/app/views/_includes/review/personal-statement.njk
+++ b/app/views/_includes/review/personal-statement.njk
@@ -28,8 +28,10 @@
           {% set feedbackFromPreviousApplications %}
             {{ feedbackFromPreviousApplications | safe }}
 
-            <p class="govuk-body govuk-!-margin-bottom-0">{{ providers[item.providerCode].name }}:</p>
-            <p class="govuk-body">“{{ item.feedback.qualityOfApplication.personalStatement | safe }}”</p>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-2">{{ providers[item.providerCode].name }}</h3>
+            <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
+              <p class="govuk-body">“{{ item.feedback.qualityOfApplication.personalStatement | safe }}”</p>
+            </blockquote>
           {% endset %}
 
         {% endif %}
@@ -40,13 +42,13 @@
   {% if hasFeedbackFromPreviousApplication %}
 
     {% set feedbackFromPreviousApplications %}
-      <h2 class="govuk-heading-s">Feedback from previous applications</h2>
+      <h2 class="govuk-heading-m">Feedback from previous applications</h2>
       {{ feedbackFromPreviousApplications | safe }}
     {% endset %}
 
     {{ govukInsetText({
       html: feedbackFromPreviousApplications | safe,
-      classes: "govuk-!-width-two-thirds app-inset-text--review"
+      classes: "govuk-!-width-two-thirds"
       })
     }}
 

--- a/app/views/_includes/review/subject-knowledge.njk
+++ b/app/views/_includes/review/subject-knowledge.njk
@@ -28,8 +28,10 @@
           {% set feedbackFromPreviousApplications %}
             {{ feedbackFromPreviousApplications | safe }}
 
-            <p class="govuk-body govuk-!-margin-bottom-0">{{ providers[item.providerCode].name }}:</p>
-            <p class="govuk-body">“{{ item.feedback.qualityOfApplication.subjectKnowledge | safe }}”</p>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-2">{{ providers[item.providerCode].name }}</h3>
+            <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
+              <p class="govuk-body">“{{ item.feedback.qualityOfApplication.subjectKnowledge | safe }}”</p>
+            </blockquote>
           {% endset %}
 
         {% endif %}
@@ -40,13 +42,13 @@
   {% if hasFeedbackFromPreviousApplication %}
 
     {% set feedbackFromPreviousApplications %}
-      <h2 class="govuk-heading-s">Feedback from previous applications</h2>
+      <h2 class="govuk-heading-m">Feedback from previous applications</h2>
       {{ feedbackFromPreviousApplications | safe }}
     {% endset %}
 
     {{ govukInsetText({
       html: feedbackFromPreviousApplications | safe,
-      classes: "govuk-!-width-two-thirds app-inset-text--review"
+      classes: "govuk-!-width-two-thirds"
       })
     }}
   {% endif %}


### PR DESCRIPTION
Maybe the pink is unnecessary? Do the headings help?

## Before

<img width="796" alt="Screenshot 2021-03-30 at 11 21 43" src="https://user-images.githubusercontent.com/30665/112977572-20480700-914e-11eb-9d76-90076fbb77ad.png">

## After

<img width="813" alt="Screenshot 2021-03-30 at 11 31 33" src="https://user-images.githubusercontent.com/30665/112977600-276f1500-914e-11eb-9a79-899bad02d599.png">
