### PR TITLE
Change "completed" checkbox to "reviewed" if there was feedback

### DIFF
--- a/app/views/application/personal-statement/review.njk
+++ b/app/views/application/personal-statement/review.njk
@@ -17,10 +17,22 @@
 {% block primary %}
   {% include "_includes/review/personal-statement.njk" %}
 
+
+  {% set hasFeedbackFromPreviousApplication = false %}
+  {% if applicationValue(["apply2"]) %}
+    {% for previousApplicationId in applicationValue("previousApplications") %}
+      {% for item in (data.applications[previousApplicationId].choices | toArray) %}
+        {% if item.feedback and item.feedback.qualityOfApplication and item.feedback.qualityOfApplication.personalStatement %}
+          {% set hasFeedbackFromPreviousApplication = true %}
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  {% endif %}
+
   {{ govukCheckboxes({
     items: [{
       value: "true",
-      text: "I have completed this section"
+      text: "I have " + ("reviewed" if hasFeedbackFromPreviousApplication else "completed") + " this section"
     }]
   } | decorateApplicationAttributes(["completed", "personalStatement"])) }}
 

--- a/app/views/application/subject-knowledge/review.njk
+++ b/app/views/application/subject-knowledge/review.njk
@@ -17,10 +17,21 @@
 {% block primary %}
   {% include "_includes/review/subject-knowledge.njk" %}
 
+  {% set hasFeedbackFromPreviousApplication = false %}
+  {% if applicationValue(["apply2"]) %}
+    {% for previousApplicationId in applicationValue("previousApplications") %}
+      {% for item in (data.applications[previousApplicationId].choices | toArray) %}
+        {% if item.feedback and item.feedback.qualityOfApplication and item.feedback.qualityOfApplication.subjectKnowledge %}
+          {% set hasFeedbackFromPreviousApplication = true %}
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  {% endif %}
+
   {{ govukCheckboxes({
     items: [{
       value: "true",
-      text: "I have completed this section"
+      text: "I have " + ("reviewed" if hasFeedbackFromPreviousApplication else "completed") + " this section"
     }]
   } | decorateApplicationAttributes(["completed", "subjectKnowledge"])) }}
 


### PR DESCRIPTION
To be consistent with the REVIEW status tag, if the candidate is applying again and a section is marked as needing review, the label of the "I have completed this section" checkbox should change to "I have reviewed this section".

## Before

<img width="412" alt="Screenshot 2021-03-31 at 10 38 57" src="https://user-images.githubusercontent.com/30665/113124557-88115700-920d-11eb-949e-a5a529d9e716.png">

## After

<img width="413" alt="Screenshot 2021-03-31 at 10 38 38" src="https://user-images.githubusercontent.com/30665/113124570-8cd60b00-920d-11eb-9cd5-182063d8cc1f.png">
