### PR TITLE
Experimental: Let candidates apply to other open courses if a course becomes full

### DIFF
--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -399,6 +399,13 @@ module.exports = router => {
         application.choices = [choices.ZYXWV]
         break
 
+      case 'one-rejection-course-full':
+        choices.ABCDE.status = 'Unsuccessful'
+        choices.ABCDE.feedback = {
+          course_full: true
+        }
+        break
+
       case 'awaiting-apply-again-response':
         choices.ABCDE.status = 'Awaiting decision'
         req.session.data.applications['12345'].choices.ABCDE.status = 'Unsuccessful'

--- a/app/views/_includes/item/feedback.njk
+++ b/app/views/_includes/item/feedback.njk
@@ -1,5 +1,12 @@
 {% if item.feedback.course_full %}
 <p class="govuk-body">The course you applied to was full.</p>
+
+<p class="govuk-body">There are still <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/results?c=England&fulltime=false&hasvacancies=true&l=1&lat=51.5073509&lng=-0.1277583&loc=London%2C+UK&lq=London&parttime=false&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&rad=50&senCourses=false&sortby=2&subjects%5B%5D=31" class="govuk-link">121 English courses open</a> in your area.</p>
+
+<div class="govuk-!-margin-top-4">
+  {{ govukButton({ text: "Apply to another course", classes: "govuk-!-margin-bottom-0" })}}
+</div>
+
 {% endif %}
 
 {% if item.feedback.rejected_by_default %}

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -99,6 +99,9 @@
     <dd>The candidate has deferred their offer until the next academic year.</dd>
     <dt><a href="/dashboard/12345/recruited">Recruited</a></dt>
     <dd>The candidate has been recruited.</dd>
+
+    <dt><a href="/dashboard/12345/one-rejection-course-full">One rejection received as course is full</a></dt>
+    <dd>Candidate can add a replacement application?</dd>
   </dl>
 
   <h3 class="govuk-heading-s">Applying again</h3>


### PR DESCRIPTION
Experimental prototype developed as part of exploring business rule changes.

The idea is that if a candidate is unsuccessful because a course is full, we prompt them to return to look at other courses, by giving them a link to a filtered pages that matches their course choices, and telling them how many courses are still open.

They can then apply to another course.

## Screenshot

<img width="731" alt="Screenshot 2021-04-30 at 15 12 08" src="https://user-images.githubusercontent.com/30665/116707343-78309280-a9c6-11eb-935d-9ee61e9d47ea.png">
