### PR TITLE
Enable new link styles

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,6 +1,7 @@
 // GOV.UK Frontend settings
 $govuk-assets-path: "/govuk/assets/";
 $govuk-global-styles: true;
+$govuk-new-link-styles: true;
 
 // Import GOV.UK Frontend and any extension styles if configured
 @import "lib/extensions/extensions";

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -33,6 +33,21 @@ $govuk-new-link-styles: true;
   word-wrap: break-word;
 }
 
+// Disable underline skipping of descenders. This is currently
+// only implemented by Safari, which also has a bug causing the
+// underline breaks to be too wide, particularly with the thicker
+// underlines that are now used on hover.
+//
+// This feature will possibly be deprecated in favour of a
+// simpler text-decoration-skip-ink: auto|none|all feature.
+//
+// If Safari fixes its bug, this could be deleted. Chrome is unaffected
+// as it is currently drawing its underline slightly further down (another
+// bug?) so isn’t skipping any descenders anyway.
+* {
+  text-decoration-skip: none;
+}
+
 // Override GOV.UK Frontend print styles
 @media print {
   .govuk-template {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "express-session": "^1.17.1",
     "express-writer": "^0.0.4",
     "fancy-log": "^1.3.3",
-    "govuk-frontend": "^3.10.2",
+    "govuk-frontend": "^3.12.0",
     "gulp": "^4.0.2",
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^4.1.0",


### PR DESCRIPTION
A new option in [GOV.UK Frontend v3.12.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.12.0), that will be become the default in the next major version.

Do we want to enable these?