### PR TITLE
Update course choice pages to match production

### DIFF
--- a/app/routes/application/choices.js
+++ b/app/routes/application/choices.js
@@ -152,7 +152,7 @@ module.exports = router => {
         const l = {}
         l.text = loc.name
         l.hint = { text: loc.address }
-        l.label = { classes: 'govuk-label--s' }
+        l.label = { classes: 'z' }
         return l
       })
 

--- a/app/views/application/choices/found.njk
+++ b/app/views/application/choices/found.njk
@@ -1,11 +1,11 @@
-{% extends "_form.njk" %}
+{% extends "_layout.njk" %}
 {% set hasCourseFromFind = data.course_from_find %}
 {% if hasCourseFromFind %}
   {% set provider = providers[data.course_from_find.providerCode] %}
   {% set course = provider.courses[data.course_from_find.courseCode] %}
   {% set title = "You selected a course" %}
 {% else %}
-  {% set title = "Have you chosen a course to apply to?" %}
+  {% set title = "Do you know which course you want to apply to?" %}
 {% endif %}
 {% set formaction = paths.current %}
 
@@ -21,49 +21,63 @@
   {% endif %}
 {% endblock %}
 
-{% block primary %}
-  {% if hasCourseFromFind %}
-    {% set courseHtml %}
-      <a href="{{ data.findUrl }}/course/T92/X130" target="_blank" class="govuk-!-font-weight-bold" style="text-decoration: none">
-        <span class="govuk-!-font-size-19">
-          {{ provider.name }}
-        </span><br>
-        <span class="search-result-link-name govuk-!-font-size-24" style="text-decoration: underline">
-          {{ course.name_and_code }}
-        </span>
-      </a>
-    {% endset %}
+{% block content %}
+  {% block beforePageTitle %}{% endblock %}
+  <form{% if formaction %} action="{{ formaction }}"{% endif %} method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+      {% if hasCourseFromFind %}
+        {% set courseHtml %}
+          <a href="{{ data.findUrl }}/course/T92/X130" target="_blank" class="govuk-!-font-weight-bold" style="text-decoration: none">
+            <span class="govuk-!-font-size-19">
+              {{ provider.name }}
+            </span><br>
+            <span class="search-result-link-name govuk-!-font-size-24" style="text-decoration: underline">
+              {{ course.name_and_code }}
+            </span>
+          </a>
+        {% endset %}
 
 
-    {{ govukInsetText({
-        html: courseHtml,
-        classes: "govuk-!-margin-top-0"
-    }) }}
+        {{ govukInsetText({
+            html: courseHtml,
+            classes: "govuk-!-margin-top-0"
+        }) }}
 
-    <h2 class="govuk-heading-m">Do you want to apply to this course?</h2>
+        <h2 class="govuk-heading-m">Do you want to apply to this course?</h2>
 
-    {{ govukRadios({
-      items: [{
-        value: "yes",
-        text: "Yes"
-      }, {
-        value: "no",
-        text: "No"
-      }]
-    } | decorateApplicationAttributes(["temporaryChoices", choiceId, "fromFind"])) }}
-  {% else %}
-    {{ govukRadios({
-      items: [{
-        value: "know",
-        text: "Yes, I know where I want to apply"
-      }, {
-        value: "need",
-        text: "No, I need to find a course"
-      }]
-    } | decorateApplicationAttributes(["temporaryChoices", choiceId, "found"])) }}
-  {% endif %}
+        {{ govukRadios({
+          items: [{
+            value: "yes",
+            text: "Yes"
+          }, {
+            value: "no",
+            text: "No"
+          }]
+        } | decorateApplicationAttributes(["temporaryChoices", choiceId, "fromFind"])) }}
+      {% else %}
+        {{ govukRadios({
+          fieldset: {
+            legend: {
+              text: title,
+              isPageTitle: true,
+              classes: "govuk-fieldset__legend--xl"
+            }
+          },
+          items: [{
+            value: "know",
+            text: "Yes, I know where I want to apply"
+          }, {
+            value: "need",
+            text: "No, I need to find a course"
+          }]
+        } | decorateApplicationAttributes(["temporaryChoices", choiceId, "found"])) }}
+      {% endif %}
 
-  {{ govukButton({
-    text: "Continue"
-  }) }}
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </div>
+  </form>
 {% endblock %}

--- a/app/views/application/choices/index.njk
+++ b/app/views/application/choices/index.njk
@@ -35,65 +35,67 @@
 {% endblock %}
 
 {% block primary %}
-  {% set guidance %}
-    <div class="govuk-!-width-two-thirds">
-      {% if applicationValue(["apply2"]) %}
-        <p class="govuk-body">You can only apply to 1 course at a time at this stage of your application.</p>
-      {% else %}
-        <p class="govuk-body">You can apply to up to 3 courses at this stage of your application.</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set guidance %}
+        {% if applicationValue(["apply2"]) %}
+          <p class="govuk-body">You can only apply to 1 course at a time at this stage of your application.</p>
+        {% else %}
+          <p class="govuk-body">You can apply to up to 3 courses at this stage of your application.</p>
+        {% endif %}
+        <p class="govuk-body">Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
+        <p class="govuk-body">You can preview <a href="/apply/providers">courses currently available</a> on Apply for teacher training.</p>
+      {% endset %}
+
+      {% if choices %}
+        {% if choicesRemaining != 0 and not applicationValue(["apply2"]) %}
+          {{ govukButton({
+            classes: "govuk-button--secondary",
+            text: "Add another course",
+            href: applicationPath + "/choices/add"
+          }) }}
+        {% endif %}
+
+        {% set referrer = applicationPath + "/choices" %}
+        {% set canAmend = true %}
+        {% set showChoiceStatus = false %}
+        {% include "_includes/review/choices.njk" %}
       {% endif %}
-      <p class="govuk-body">Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
-      <p class="govuk-body">You can preview <a href="/apply/providers">courses currently available</a> on Apply for teacher training.</p>
+
+      {% if not choices or choicesCount == 0 %}
+        {{ guidance | safe }}
+
+        {{ govukButton({
+          text: "Continue",
+          href: applicationPath + "/choices/add"
+        }) }}
+      {% endif %}
+
+      {% if choicesCount >= 1 %}
+        {{ govukRadios({
+          fieldset: {
+            classes: "govuk-!-width-two-thirds",
+            legend: {
+              text: "Have you completed this section?",
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          hint: {
+            text: "You can add " + choicesRemaining + (" more courses" if choicesRemaining > 1 else " more course")
+          } if not applicationValue(["apply2"]) and choicesRemaining != 0,
+          items: [{
+            value: "true",
+            text: "Yes, I’ve completed this section"
+          }, {
+            value: "false",
+            text: "No, I’ll come back to it later"
+          }]
+        } | decorateApplicationAttributes(["completed", "choices"])) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      {% endif %}
     </div>
-  {% endset %}
-
-  {% if choices %}
-    {% if choicesRemaining != 0 and not applicationValue(["apply2"]) %}
-      {{ govukButton({
-        classes: "govuk-button--secondary",
-        text: "Add another course",
-        href: applicationPath + "/choices/add"
-      }) }}
-    {% endif %}
-
-    {% set referrer = applicationPath + "/choices" %}
-    {% set canAmend = true %}
-    {% set showChoiceStatus = false %}
-    {% include "_includes/review/choices.njk" %}
-  {% endif %}
-
-  {% if not choices or choicesCount == 0 %}
-    {{ guidance | safe }}
-
-    {{ govukButton({
-      text: "Continue",
-      href: applicationPath + "/choices/add"
-    }) }}
-  {% endif %}
-
-  {% if choicesCount >= 1 %}
-    {{ govukRadios({
-      fieldset: {
-        classes: "govuk-!-width-two-thirds",
-        legend: {
-          text: "Have you completed this section?",
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      hint: {
-        text: "You can add " + choicesRemaining + (" more courses" if choicesRemaining > 1 else " more course")
-      } if not applicationValue(["apply2"]) and choicesRemaining != 0,
-      items: [{
-        value: "true",
-        text: "Yes, I’ve completed this section"
-      }, {
-        value: "false",
-        text: "No, I’ll come back to it later"
-      }]
-    } | decorateApplicationAttributes(["completed", "choices"])) }}
-
-    {{ govukButton({
-      text: "Continue"
-    }) }}
-  {% endif %}
+  </div>
 {% endblock %}

--- a/app/views/application/choices/location.njk
+++ b/app/views/application/choices/location.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "Pick a course location" %}
+{% set title = "Which location are you applying to?" %}
 {% set formaction = paths.next %}
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -9,8 +9,6 @@
 {% endblock %}
 
 {% block primary %}
-  <p>This course is offered in different locations. Pick the location you would prefer to be based in.</p>
-
   {{ govukRadios({
     items: locationOptions
   } | decorateApplicationAttributes(["temporaryChoices", choiceId, "location"])) }}

--- a/app/views/application/choices/pick.njk
+++ b/app/views/application/choices/pick.njk
@@ -24,30 +24,27 @@
 
 {% block primary %}
   {% if providerOnDfEApply %}
-    {% set courseAutocompleteHtml %}
-      <div class="govuk-form-group">
-        <label class="govuk-label" for="courses-{{ choiceId }}-course">Enter course name and code</label>
-        <div id="course-autocomplete-container"></div>
-      </div>
-    {% endset %}
-
     {% if data.course_from_find and providerCode == data.course_from_find.providerCode %}
-      {% set course = provider.courses[data.course_from_find.courseCode] %}
-      {{ govukRadios({
-        items: [{
-          text: course.name_and_code
-        }, {
-          divider: "or"
-        }, {
-          text: "Another course",
-          value: "another",
-          conditional: {
-            html: courseAutocompleteHtml
-          }
-        }]
-      } | decorateApplicationAttributes(["temporaryChoices", choiceId, "courseFromFind"])) }}
+      {# TODO #}
+
     {% else %}
-      {{ courseAutocompleteHtml | safe }}
+
+      {% set courseItems = [] %}
+      {% for course in courses %}
+        {% set courseItems = courseItems | push({
+          text: course.name_and_code,
+          value: course.name_and_code,
+          hint: {
+            text: course.description
+          }
+        }) %}
+      {% endfor %}
+
+      {{ govukRadios({
+        idPrefix: "course",
+        items: courseItems,
+        name: "applications[" + applicationId + "][temporaryChoices][" + choiceId + "][course]"
+      }) }}
     {% endif %}
 
     {{ govukButton({
@@ -80,38 +77,5 @@
       <p class="govuk-body">or</p>
       <p class="govuk-body"><a href="{{ applicationPath }}" class="govuk-link">Return to your application</a></p>
     {% endif %}
-  {% endif %}
-{% endblock %}
-
-{% block pageScripts %}
-  {% if providerOnDfEApply %}
-    <script src="/public/javascripts/autocomplete.min.js"></script>
-    <script>
-      {% if editing %}
-        {% set defaultValue = provider.courses[applicationValue(["choices", choiceId, "courseCode"])].name_and_code %}
-
-        accessibleAutocomplete({
-          element: document.querySelector('#course-autocomplete-container'),
-          id: 'courses-{{ choiceId }}-course',
-          name: "applications[{{ applicationId }}][temporaryChoices][{{ choiceId }}][course]",
-          defaultValue: "",
-          showAllValues: true,
-          source: [
-            {% for course in courses %}"{{ course.name_and_code }}",{% endfor %}
-          ]
-        })
-      {% else %}
-        accessibleAutocomplete({
-          element: document.querySelector('#course-autocomplete-container'),
-          id: 'courses-{{ choiceId }}-course',
-          name: "applications[{{ applicationId }}][temporaryChoices][{{ choiceId }}][course]",
-          defaultValue: '{{ applicationValue(["temporaryChoices", choiceId, "course"]) }}',
-          showAllValues: true,
-          source: [
-            {% for course in courses %}"{{ course.name_and_code }}",{% endfor %}
-          ]
-        })
-      {% endif %}
-    </script>
   {% endif %}
 {% endblock %}

--- a/app/views/application/choices/provider.njk
+++ b/app/views/application/choices/provider.njk
@@ -1,42 +1,51 @@
-{% extends "_form.njk" %}
+{% extends "_layout.njk" %}
 
 {% set title = "Which training provider are you applying to?" %}
 {% set formaction = paths.next %}
 {% block pageNavigation %}{{ govukBackLink({ href: paths.back }) }}{% endblock %}
 
-{% block primary %}
+{% block content %}
+  {% block beforePageTitle %}{% endblock %}
+  <form{% if formaction %} action="{{ formaction }}"{% endif %} method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
 
-<p class="govuk-body">You can <a href="/apply/providers">preview a list of training providers and courses</a> currently available on Apply for teacher training.</p>
-  {% set providerAutocompleteHTML %}
-    <div class="govuk-form-group">
-      <label class="govuk-label" for="courses-{{ choiceId }}-provider">Enter training provider name</label>
-      <div id="provider-autocomplete-container"></div>
+        {% set providerAutocompleteHTML %}
+          <div class="govuk-form-group">
+            <h1>
+              <label class="govuk-label govuk-label--xl" for="courses-{{ choiceId }}-provider">{{ title}} </label>
+            </h1>
+            <p class="govuk-body">You can <a href="/apply/providers">see a list of training providers and courses</a> currently available on Apply for teacher training.</p>
+
+            <div id="provider-autocomplete-container"></div>
+          </div>
+        {% endset %}
+
+        {% if data.course_from_find and providers[data.course_from_find.providerCode] %}
+          {% set provider = providers[data.course_from_find.providerCode] %}
+
+          {{ govukRadios({
+            items: [{
+              text: provider.name_and_code
+            }, {
+              divider: "or"
+            }, {
+              text: "Another provider",
+              value: "another",
+              conditional: {
+                html: providerAutocompleteHTML
+              }
+            }]
+          } | decorateApplicationAttributes(["temporaryChoices", choiceId, "providerFromFind"])) }}
+        {% else %}
+          {{ providerAutocompleteHTML | safe }}
+        {% endif %}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
     </div>
-  {% endset %}
-
-  {% if data.course_from_find and providers[data.course_from_find.providerCode] %}
-    {% set provider = providers[data.course_from_find.providerCode] %}
-
-    {{ govukRadios({
-      items: [{
-        text: provider.name_and_code
-      }, {
-        divider: "or"
-      }, {
-        text: "Another provider",
-        value: "another",
-        conditional: {
-          html: providerAutocompleteHTML
-        }
-      }]
-    } | decorateApplicationAttributes(["temporaryChoices", choiceId, "providerFromFind"])) }}
-  {% else %}
-    {{ providerAutocompleteHTML | safe }}
-  {% endif %}
-
-  {{ govukButton({
-    text: "Continue"
-  }) }}
+  </div>
 {% endblock %}
 
 {% block pageScripts %}
@@ -47,6 +56,7 @@
       name: "applications[{{ applicationId }}][temporaryChoices][{{ choiceId }}][provider]",
       id: 'courses-{{ choiceId }}-provider',
       minLength: 2,
+      showAllValues: true,
       source: [
         {% for id, item in providers %}"{{ item.name_and_code }}",{% endfor %}
       ]


### PR DESCRIPTION
This applies a bunch of content and UI changes from the course choice flow in production to the prototype.

Changes:

* "Have you chosen a course to apply to?" changed to "Do you know which course you want to apply to?"
* "Pick a course location" changed to "Which location are you applying to?"
* Location names in radios lose their boldness
* Course selection changed from autocomplete to radios to match production
* Provider autocomplete gains a dropdown arrow
* Summary cards on review page are only 2/3rds width

I’ve quite possibly still missed some things. Also need to get my head around how the Apply -> Find -> Apply integration works.