### PR TITLE
Upgrade govuk-frontend and enable new links styles

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -2,6 +2,10 @@
 $govuk-assets-path: "/govuk/assets/";
 $govuk-global-styles: true;
 
+// Enable new link styles (currently opt-in).
+// TODO: remove this when this becomes the default.
+$govuk-new-link-styles: true;
+
 // Import GOV.UK Frontend and any extension styles if configured
 @import "lib/extensions/extensions";
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "express-session": "^1.17.1",
     "express-writer": "^0.0.4",
     "fancy-log": "^1.3.3",
-    "govuk-frontend": "^3.10.2",
+    "govuk-frontend": "^3.13.0",
     "gulp": "^4.0.2",
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^4.1.0",


### PR DESCRIPTION
The [new link styles](https://github.com/alphagov/govuk-frontend/releases/tag/v3.12.0) are currently opt-in. The main differences are:

> Links now have underlines that are consistently thinner and a bit further away from the link text.
>
> Links also have a clearer hover state, where the underline gets thicker to make the link stand out to users.

Version 3.13.0 of govuk-frontend [disables ink skipping of underlines in hover state](https://github.com/alphagov/govuk-frontend/pull/2251) to avoid large gaps appearing in the underline on hover in Safari and Firefox.