### PR TITLE
Remove course choices interstitial pages

### DIFF
--- a/app/routes/application/choices.js
+++ b/app/routes/application/choices.js
@@ -195,4 +195,15 @@ module.exports = router => {
       found: temporaryChoice.found
     })
   })
+
+  router.get('/application/:applicationId/choices', (req, res) => {
+    const { applicationId } = req.params
+    const application = utils.applicationData(req)
+
+    if (utils.toArray(application.choices).length == 0) {
+      res.redirect(`/application/${applicationId}/choices/add`)
+    } else {
+      res.render(`application/choices/index`)
+    }
+  })
 }

--- a/app/views/application/choices/another.njk
+++ b/app/views/application/choices/another.njk
@@ -23,7 +23,7 @@
 {% set formaction = paths.current %}
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: paths.back
+    href: "/application/" + applicationId + "/choices"
   }) }}
 {% endblock %}
 

--- a/app/views/application/choices/find.njk
+++ b/app/views/application/choices/find.njk
@@ -2,7 +2,12 @@
 
 {% set title = "Find a course" %}
 {% set formaction = paths.next %}
-{% block pageNavigation %}{{ govukBackLink({ href: paths.back }) }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/application/" + applicationId + "/choices/" + choiceId + "/found"
+  }) }}
+{% endblock %}
 
 {% block primary %}
   <p class="govuk-body-l">Search for courses near you on Find postgraduate teacher&nbsp;training.</p>

--- a/app/views/application/choices/found.njk
+++ b/app/views/application/choices/found.njk
@@ -1,5 +1,7 @@
 {% extends "_layout.njk" %}
 {% set hasCourseFromFind = data.course_from_find %}
+{% set choices = applicationValue("choices") | toArray %}
+
 {% if hasCourseFromFind %}
   {% set provider = providers[data.course_from_find.providerCode] %}
   {% set course = provider.courses[data.course_from_find.courseCode] %}
@@ -9,16 +11,18 @@
 {% endif %}
 {% set formaction = paths.current %}
 
+{% if data["from"] == "application" or (choices | length) == 0 %}
+  {% set backLinkHref = "/application/" + applicationId %}
+{% elif applicationValue("welcomeFlow") %}
+  {% set backLinkHref = "/application/" + applicationId + "/before-you-start" %}
+{% else %}
+  {% set backLinkHref = "/application/" + applicationId + "/choices" %}
+{% endif %}
+
 {% block pageNavigation %}
-  {% if not applicationValue("welcomeFlow") %}
-    {{ govukBackLink({
-      href: paths.back
-    }) }}
-  {% else %}
-    {{ govukBackLink({
-      href: "/application/" + applicationId + "/before-you-start"
-    }) }}
-  {% endif %}
+  {{ govukBackLink({
+    href: backLinkHref
+  }) }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/application/choices/index.njk
+++ b/app/views/application/choices/index.njk
@@ -37,65 +37,42 @@
 {% block primary %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% set guidance %}
-        {% if applicationValue(["apply2"]) %}
-          <p class="govuk-body">You can only apply to 1 course at a time at this stage of your application.</p>
-        {% else %}
-          <p class="govuk-body">You can apply to up to 3 courses at this stage of your application.</p>
-        {% endif %}
-        <p class="govuk-body">Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
-        <p class="govuk-body">You can preview <a href="/apply/providers">courses currently available</a> on Apply for teacher training.</p>
-      {% endset %}
-
-      {% if choices %}
-        {% if choicesRemaining != 0 and not applicationValue(["apply2"]) %}
-          {{ govukButton({
-            classes: "govuk-button--secondary",
-            text: "Add another course",
-            href: applicationPath + "/choices/add"
-          }) }}
-        {% endif %}
-
-        {% set referrer = applicationPath + "/choices" %}
-        {% set canAmend = true %}
-        {% set showChoiceStatus = false %}
-        {% include "_includes/review/choices.njk" %}
-      {% endif %}
-
-      {% if not choices or choicesCount == 0 %}
-        {{ guidance | safe }}
-
+      {% if choicesRemaining != 0 and not applicationValue(["apply2"]) %}
         {{ govukButton({
-          text: "Continue",
-          href: applicationPath + "/choices/add"
+          classes: "govuk-button--secondary",
+          text: "Add another course",
+          href: applicationPath + "/choices/add?from=choices"
         }) }}
       {% endif %}
 
-      {% if choicesCount >= 1 %}
-        {{ govukRadios({
-          fieldset: {
-            classes: "govuk-!-width-two-thirds",
-            legend: {
-              text: "Have you completed this section?",
-              classes: "govuk-fieldset__legend--m"
-            }
-          },
-          hint: {
-            text: "You can add " + choicesRemaining + (" more courses" if choicesRemaining > 1 else " more course")
-          } if not applicationValue(["apply2"]) and choicesRemaining != 0,
-          items: [{
-            value: "true",
-            text: "Yes, I’ve completed this section"
-          }, {
-            value: "false",
-            text: "No, I’ll come back to it later"
-          }]
-        } | decorateApplicationAttributes(["completed", "choices"])) }}
+      {% set referrer = applicationPath + "/choices" %}
+      {% set canAmend = true %}
+      {% set showChoiceStatus = false %}
+      {% include "_includes/review/choices.njk" %}
 
-        {{ govukButton({
-          text: "Continue"
-        }) }}
-      {% endif %}
+      {{ govukRadios({
+        fieldset: {
+          classes: "govuk-!-width-two-thirds",
+          legend: {
+            text: "Have you completed this section?",
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: {
+          text: "You can add " + choicesRemaining + (" more courses" if choicesRemaining > 1 else " more course")
+        } if not applicationValue(["apply2"]) and choicesRemaining != 0,
+        items: [{
+          value: "true",
+          text: "Yes, I’ve completed this section"
+        }, {
+          value: "false",
+          text: "No, I’ll come back to it later"
+        }]
+      } | decorateApplicationAttributes(["completed", "choices"])) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
     </div>
   </div>
 {% endblock %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -90,10 +90,16 @@
       {% endif %}
     {% endif %}
 
+    {% if applicationValue("choices") | toArray | length == 0 %}
+      {% set choicesHref = applicationPath + "/choices/add?from=application" %}
+    {% else %}
+      {% set choicesHref = applicationPath + "/choices" %}
+    {% endif %}
+
     {{ appTaskList({
       items: [{
         text: "Choose your course" if apply2 else "Choose your courses",
-        href: applicationPath + "/choices",
+        href: choicesHref,
         id: "personal-information",
         tag: {
           classes: tagClass if applicationValue(["completed", "choices"]) else incompleteTagClass,


### PR DESCRIPTION
As we no longer need to mention the UCAS dual-running from September, we can remove the interstitial page which explains this:

> <img width="730" alt="Screenshot 2021-06-25 at 11 19 47" src="https://user-images.githubusercontent.com/30665/123410485-4cd1ba80-d5a7-11eb-9332-1a9ff6cfe941.png">

The "You can apply for up to 3 courses." message is already on the application index page.

Instead, from the application index page, the "Choose your courses" link can go directly to the "Do you know which course you want to apply to?" page.

If you delete a course choice from the course choices index page, you are redirected to the "Do you know which course you want to apply to?" page again, rather than being shown an empty page.

(Also fixes some back links)