### PR TITLE
Revert gulp-sass upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "govuk-frontend": "^3.13.0",
     "gulp": "^4.0.2",
     "gulp-nodemon": "^2.5.0",
-    "gulp-sass": "^5.0.0",
+    "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^3.0.0",
     "humanize-duration": "^3.25.1",
     "keypather": "^3.1.0",


### PR DESCRIPTION
version 5 requires sass to be installed separately