### PR TITLE
Show application withdrawn by provider

### DIFF
--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -113,6 +113,13 @@ module.exports = router => {
         break
       case 'withdrawn':
         choices.ABCDE.status = 'Application withdrawn'
+        choices.ABCDE.withdrawnByProvider = false
+        choices.ABCDE.rejectedByDefault = false
+        choices.ABCDE.feedback = null
+        break
+      case 'withdrawn-by-provider':
+        choices.ABCDE.status = 'Application withdrawn'
+        choices.ABCDE.withdrawnByProvider = true
         choices.ABCDE.rejectedByDefault = false
         choices.ABCDE.feedback = null
         break

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -46,6 +46,8 @@
     <dd>Candidate can apply again</dd>
     <dt><a href="/dashboard/45678/withdrawn">Candidate withdrew application</a></dt>
     <dd>Candidate can apply again</dd>
+    <dt><a href="/dashboard/45678/withdrawn-by-provider">Provider withdrew application at candidate’s request</a></dt>
+    <dd>Candidate can apply again</dd>
     <dt><a href="/dashboard/45678/offer-withdrawn">Offer withdrawn by provider</a></dt>
     <dd>Candidate can apply again</dd>
     <dt><a href="/dashboard/45678/accepted">Accepted (pending conditions)</a></dt>

--- a/app/views/dashboard/_course-choices.njk
+++ b/app/views/dashboard/_course-choices.njk
@@ -31,6 +31,12 @@
       <p class="govuk-body govuk-!-margin-top-2">The provider must make a decision by  {{ 14 | nowPlusDays("d MMMM yyyy") }}.</p>
     {% endif %}
 
+    {% if item.status == "Application withdrawn" and item.withdrawnByProvider == true %}
+      <p class="govuk-body govuk-!-margin-top-2">The provider withdrew the application at your request.</p>
+
+      <p class="govuk-body">If you did not request this, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+    {% endif %}
+
     {% if item.offeredCourseId %}
 
       {% if item.offeredProviderId %}


### PR DESCRIPTION
The provider team have added a feature enabling provider to withdraw an application at the candidate’s request.

This shows how we can represent this to the candidate in the post-submission dashboard.

An extra line is added to encourage candidates to contact support if they didn't request their application to be withdrawn.

The rest of the page, including the call to action to apply again, is unchanged.

## Screenshot

<img width="699" alt="Screenshot 2021-07-12 at 16 06 29" src="https://user-images.githubusercontent.com/30665/125311221-2643ab80-e32b-11eb-898a-c058642a4591.png">
