### PR TITLE
Bugfix: missing course details when adding course

### DIFF
--- a/app/routes/application/choices.js
+++ b/app/routes/application/choices.js
@@ -107,12 +107,19 @@ module.exports = router => {
     const { applicationId, choiceId } = req.params
     const paths = pickPaths(req)
 
+    const selectedCourseProviderCode = providerCode(req)
+    const selectedCourseCode = courseCode(req)
+    const courseSelected = providers[selectedCourseProviderCode].courses[selectedCourseCode]
+
     application.choices[choiceId] = {
-      providerCode: providerCode(req),
-      courseCode: courseCode(req),
+      providerCode: selectedCourseProviderCode,
+      courseCode: selectedCourseCode,
       locationName: locationName(req),
       locationAddress: locationAddress(req),
-      singleLocationCourse: singleLocationCourse(req)
+      singleLocationCourse: singleLocationCourse(req),
+      length: '1 year',
+      type: courseSelected.description,
+      starts: '2022-09'
     }
 
     delete req.session.data.course_from_find


### PR DESCRIPTION
The course length, type and start date of courses weren’t being filled out when adding courses:

<img width="660" alt="Screenshot 2021-07-15 at 11 37 23" src="https://user-images.githubusercontent.com/30665/125776179-0b12aa42-daa9-4012-91a5-e03b163b1772.png">

This fixes this, by taking the course type from the courses data JSON file, and hardcoding the other 2.