### PR TITLE
Bugfix: toArray should always return an array

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -169,7 +169,7 @@ module.exports = (env) => {
   }
 
   /**
-   * Convert object to array
+   * Convert object to array, or return empty array.
    * @type {Object} obj
    */
   filters.toArray = (obj) => {
@@ -180,6 +180,8 @@ module.exports = (env) => {
         arr.push(value)
       }
       return arr
+    } else {
+      return []
     }
   }
 

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -179,6 +179,8 @@ const toArray = (obj) => {
       arr.push(value)
     }
     return arr
+  } else {
+    return []
   }
 }
 


### PR DESCRIPTION
When toArray is called on an `undefined` or `null` object, an empty array should be returned.

This prevents errors occurring if you try to filter the returned object, such as:

```
TypeError: Cannot read property 'filter' of undefined
```