### PR TITLE
Show warning if degree class doesn't meet minimum required

### DIFF
--- a/app/data/application.js
+++ b/app/data/application.js
@@ -32,7 +32,8 @@ module.exports = {
       type: 'PGCE with QTS full time',
       length: '1 year',
       starts: '2021-09',
-      status: 'Awaiting decision'
+      status: 'Awaiting decision',
+      degreeRequired: 'degree'
     },
     FGHIJ: {
       courseCode: '38PN',
@@ -43,7 +44,8 @@ module.exports = {
       type: 'PGCE with QTS full time',
       length: '1 year',
       starts: '2021-09',
-      status: 'Awaiting decision'
+      status: 'Awaiting decision',
+      degreeRequired: 'degree'
     },
     ZYXWV: {
       courseCode: '3C2X',
@@ -54,7 +56,8 @@ module.exports = {
       type: 'PGCE with QTS full time',
       length: '1 year',
       starts: '2021-09',
-      status: 'Awaiting decision'
+      status: 'Awaiting decision',
+      degreeRequired: 'third'
     }
   },
   references: {

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -5,6 +5,13 @@ const internationalApplicationNoRightToStudyYet = JSON.parse(JSON.stringify(requ
 internationalApplicationNoRightToStudyYet.candidate.residencyDisclose = 'I will need to apply for permission to work or study in the UK'
 internationalApplicationNoRightToStudyYet.candidate.residency  = ''
 
+applicationWhereNotMeetingMinimiumDegreeRequirement =  JSON.parse(JSON.stringify(require('./application')))
+
+applicationWhereNotMeetingMinimiumDegreeRequirement.choices.ABCDE.degreeRequired = "21"
+applicationWhereNotMeetingMinimiumDegreeRequirement.choices.FGHIJ.degreeRequired = "22"
+applicationWhereNotMeetingMinimiumDegreeRequirement.choices.ZYXWV.degreeRequired = "third"
+applicationWhereNotMeetingMinimiumDegreeRequirement.degree.abcde.grade = "Third-class honours"
+
 module.exports = {
   applications: {
     12345: require('./application'),
@@ -14,7 +21,8 @@ module.exports = {
     ABCDE: require('./application-with-choices'),
     45678: require('./application-single-choice'),
     GLOBE: require('./application-international'),
-    21234: internationalApplicationNoRightToStudyYet
+    21234: internationalApplicationNoRightToStudyYet,
+    52614: applicationWhereNotMeetingMinimiumDegreeRequirement
   },
   findUrl: 'https://www.find-postgraduate-teacher-training.service.gov.uk',
   flags: {

--- a/app/routes/application/choices.js
+++ b/app/routes/application/choices.js
@@ -80,6 +80,19 @@ const singleLocationCourse = (req) => {
   return locations.length === 1
 }
 
+const randomDegreeRequirement = (seed) => {
+ switch (Math.floor(Math.random(seed) * 5)) {
+    case 0:
+      return '21'
+    case 1:
+      return '22'
+    case 2:
+      return 'third'
+    default:
+      return 'degree'
+  }
+}
+
 module.exports = router => {
   router.all('/application/:applicationId/choices/add', (req, res) => {
     const { applicationId } = req.params
@@ -109,6 +122,9 @@ module.exports = router => {
     // Randomised for now, until this data is added to Find and the API
     const canSponsorVisa = (Math.random(choiceId) > 0.5)
 
+    // Adding random degree class requirement
+    const degreeRequired = randomDegreeRequirement(choiceId)
+
     application.choices[choiceId] = {
       providerCode: selectedCourseProviderCode,
       courseCode: selectedCourseCode,
@@ -118,7 +134,8 @@ module.exports = router => {
       length: '1 year',
       type: courseSelected.description,
       starts: '2022-09',
-      canSponsorVisa: canSponsorVisa
+      canSponsorVisa: canSponsorVisa,
+      degreeRequired: degreeRequired
     }
 
     delete req.session.data.course_from_find

--- a/app/utils/filters-with-app-context.js
+++ b/app/utils/filters-with-app-context.js
@@ -121,6 +121,12 @@ module.exports = (nunjucksAppEnv, app) => {
       return utils.hasPrimaryChoices(req)
     })
 
+    nunjucksAppEnv.addGlobal('highestDegreeGrade', () => {
+      return utils.highestDegreeGrade(req)
+    })
+
+
+
     next()
   })
 }

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -171,6 +171,29 @@ const hasPrimaryChoices = (req) => {
   }
 }
 
+const highestDegreeGrade = (req) => {
+
+  const application = applicationData(req)
+  const degrees = toArray(application.degree)
+
+  const degreeGrades = degrees.map(degree => degree.grade)
+
+  if (degreeGrades.includes("First-class honours")) {
+    return "first"
+  } else if (degreeGrades.includes("Upper second-class honours (2:1)")) {
+    return "21"
+  } else if (degreeGrades.includes("Lower second-class honours (2:2)")) {
+    return "22"
+  } else if (degreeGrades.includes("Third-class honours")) {
+    return "third"
+  } else if (degreeGrades.includes("Pass")) {
+    return "pass"
+  } else {
+    return null
+  }
+}
+
+
 const toArray = (obj) => {
   if (obj) {
     const arr = []
@@ -201,5 +224,6 @@ module.exports = {
   hasSubmittedApplications,
   hasStartedApplications,
   toArray,
-  defaultSessionData
+  defaultSessionData,
+  highestDegreeGrade
 }

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -79,7 +79,7 @@
   {% elif item.degreeRequired == "22" %}
     2:2 degree or higher (or equivalent)
   {% elif item.degreeRequired == "third" %}
-    Third class degree or higher (or equivalent)
+    Third-class degree or higher (or equivalent)
   {% else %}
     Any undergraduate degree
   {% endif %}
@@ -109,7 +109,7 @@
         {% if candidateHighestDegreeGrade == "22" %}
           a 2:2
         {% elif candidateHighestDegreeGrade == "third" %}
-          a third class
+          a third-class
         {% else %}
           an ordinary (pass)
         {% endif %}

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -73,6 +73,60 @@
   {% endif %}
 {% endset %}
 
+{% set degreeRequired %}
+  {% if item.degreeRequired == "21" %}
+    2:1 degree or higher (or equivalent)
+  {% elif item.degreeRequired == "22" %}
+    2:2 degree or higher (or equivalent)
+  {% elif item.degreeRequired == "third" %}
+    Third class degree or higher (or equivalent)
+  {% else %}
+    Any undergraduate degree
+  {% endif %}
+{% endset %}
+
+{% set candidateHighestDegreeGrade = highestDegreeGrade() %}
+
+{% set degreeRequiredHtml %}
+
+  {% if (item.degreeRequired == "21" and (candidateHighestDegreeGrade == "22" or candidateHighestDegreeGrade == "third" or candidateHighestDegreeGrade == "pass")) or (item.degreeRequired == "22" and (candidateHighestDegreeGrade == "third" or candidateHighestDegreeGrade == "pass")) or (item.degreeRequired == "third" and (candidateHighestDegreeGrade == "pass")) %}
+
+    {% set degreeRequiredWarningHtml %}
+      <p class="govuk-heading-s app-inset-text__title">{{ degreeRequired }}</p>
+
+      {% set firstDegree = applicationValue("degree") | toArray | first %}
+
+      <p class="govuk-body">
+        You said
+
+        {# Ideally this would check the completed status of your highest degree grade #}
+        {% if firstDegree["completed"] == "Yes" %}
+          you have
+        {% else %}
+          you’re expecting
+        {% endif %}
+
+        {% if candidateHighestDegreeGrade == "22" %}
+          a 2:2
+        {% elif candidateHighestDegreeGrade == "third" %}
+          a third class
+        {% else %}
+          an ordinary (pass)
+        {% endif %}
+      degree.</p>
+
+      <p class="govuk-body">Contact the provider to see if they will still consider your application.</p>
+    {% endset %}
+
+    {{ govukInsetText({
+      html: degreeRequiredWarningHtml,
+      classes: "app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1"
+    })}}
+  {% else %}
+    {{ degreeRequired }}
+  {% endif %}
+{% endset %}
+
 {{ govukSummaryList({
   rows: [{
     key: {
@@ -125,6 +179,13 @@
       html: startDate
     } if item.starts
   } if (showChoiceDetails !== false) and (item.status !== "Offer deferred"), {
+    key: {
+      text: "Degree required"
+    },
+    value: {
+      html: degreeRequiredHtml
+    }
+  }, {
     key: {
       text: "Visa sponsorship"
     },

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -115,7 +115,12 @@
         {% endif %}
       degree.</p>
 
-      <p class="govuk-body">Contact the provider to see if they will still consider your application.</p>
+      <p class="govuk-body">You can:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>find a course that has a lower degree requirement</li>
+        <li>contact the provider to see if they will still consider your application</li>
+      </ul>
     {% endset %}
 
     {{ govukInsetText({

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -103,9 +103,12 @@
     <dd>The candidate has been recruited.</dd>
   </dl>
 
-  <h3 class="govuk-heading-s">International candidates</h3>
+  <h3 class="govuk-heading-s">Entry requirements</h3>
 
   <dl class="govuk-list app-list--definition">
+    <dt><a href="/application/52614">Has a 2:2 degree, applying to a course requiring a 2:1</a></dt>
+    <dd>The candidate will see some guidance</dd>
+
     <dt><a href="/application/21234">Does not yet have right to work in the UK, applying to a course which can sponsor a visa</a></dt>
     <dd>The candidate will see some guidance</dd>
   </dl>


### PR DESCRIPTION
This adds a warning message to the Course choices section (and the review page) if the candidate’s highest degree grade doesn't meet the minimum required for a course.

<img width="730" alt="Screenshot 2021-07-16 at 13 54 51" src="https://user-images.githubusercontent.com/30665/125951071-5c1202b4-f1c3-409d-b971-aab2672514c2.png">

If the degree grade is predicted, the message is slightly different:

<img width="742" alt="Screenshot 2021-07-16 at 13 55 10" src="https://user-images.githubusercontent.com/30665/125951104-79d0da16-b2a5-4dac-8a78-be12bb799050.png">

If the degree grade cannot directly be compared to the minimum requirement (eg because it’s an international degree), or if the candidate meets the minimum degree required, then just the minimum requirement is shown:

<img width="736" alt="Screenshot 2021-07-16 at 13 56 02" src="https://user-images.githubusercontent.com/30665/125951181-49db673c-6a0d-4157-97b6-127390d99ddf.png">
