### PR TITLE
Change "expected grade" content

### DIFF
--- a/app/views/_includes/item/degrees.njk
+++ b/app/views/_includes/item/degrees.njk
@@ -128,7 +128,7 @@
         } if canAmend
       } if item.hasGrade, {
         key: {
-          text: "Grade" if item.completed == "Yes" else "Predicted grade"
+          text: "Grade" if item.completed == "Yes" else "Expected grade"
         },
         value: {
           text: item.grade or "Not entered"

--- a/app/views/application/degree/grade.njk
+++ b/app/views/application/degree/grade.njk
@@ -1,4 +1,4 @@
-{% extends "_form.njk" %}
+{% extends "_layout.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set international = applicationValue(["degree", id, "provenance"]) == "international" %}
@@ -14,7 +14,7 @@
   {% if international %}
     {% set title = "Will your degree give a grade?" %}
   {% else %}
-    {% set title = "What grade do you think you’ll get?" %}
+    {% set title = "What grade do you expect to get?" %}
   {% endif %}
 {% endif %}
 {% set allowsFeedback = true %}
@@ -25,87 +25,101 @@
   }) }}
 {% endblock %}
 
-{% block primary %}
-  {% if not completed and not international %}
-    {{ govukInsetText({
-      text: "You must give an academic referee who can agree that you’re aiming for this grade."
-    }) }}
-  {% endif %}
+{% block content %}
+  <form{% if formaction %} action="{{ formaction }}"{% endif %} method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {% set internationalGradeHtml %}
+          {{ govukInput({
+            label: {
+              text: "What grade do you expect to get?"
+            },
+            hint: {
+              text: "Your expected grade should be confirmed by an academic referee."
+            } if not completed,
+            classes: "govuk-input--width-20"
+          } | decorateApplicationAttributes(["degree", id, "grade"])) }}
+        {% endset %}
 
-  {% set internationalGradeHtml %}
-    {{ govukInput({
-      label: {
-        text: "Enter your degree grade"
-      },
-      hint: {
-        text: "Enter the grade that you think you’ll get. You must give an academic referee who can agree that you’re aiming for this grade."
-      } if not completed,
-      classes: "govuk-input--width-20"
-    } | decorateApplicationAttributes(["degree", id, "grade"])) }}
-  {% endset %}
+        {% set otherUkGradeHtml %}
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="degree-{{ id }}-gradeOther">Enter your degree grade</label>
+            <div id="grade-autocomplete-container" class="govuk-input--width-20"></div>
+          </div>
+        {% endset %}
 
-  {% set otherUkGradeHtml %}
-    <div class="govuk-form-group">
-      <label class="govuk-label" for="degree-{{ id }}-gradeOther">Enter your degree grade</label>
-      <div id="grade-autocomplete-container" class="govuk-input--width-20"></div>
+        {% if international %}
+          {{ govukRadios({
+            fieldset: {
+              legend: {
+                html: title,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--xl"
+              }
+            },
+            hint: {
+              text: 'For example, ‘A’, ‘4.5’, ‘94%’, ‘Distinction’'
+            },
+            items: [{
+              text: "Yes",
+              conditional: {
+                html: internationalGradeHtml
+              }
+            }, {
+              text: "No"
+            }, {
+              text: "I do not know"
+            }]
+          } | decorateApplicationAttributes(["degree", id, "hasGrade"])) }}
+        {% else %}
+          {{ govukRadios({
+            fieldset: {
+              legend: {
+                html: title,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--xl"
+              }
+            },
+            hint: {
+              text: "Your expected grade should be confirmed by an academic referee."
+            } if not completed and not international,
+            items: [{
+              value: "First-class honours",
+              text: "First-class honours"
+            } if not international, {
+              value: "Upper second-class honours (2:1)",
+              text: "Upper second-class honours (2:1)"
+            } if not international, {
+              value: "Lower second-class honours (2:2)",
+              text: "Lower second-class honours (2:2)"
+            } if not international, {
+              value: "Third-class honours",
+              text: "Third-class honours"
+            } if not international, {
+              text: "Distinction"
+            } if not (undergraduateDegree or international), {
+              text: "Merit"
+            } if not (undergraduateDegree or international), {
+              text: "Pass"
+            } if not international, {
+              text: "Not applicable"
+            } if not undergraduateDegree, {
+              text: "Unknown"
+            } if not undergraduateDegree, {
+              text: "Other",
+              conditional: {
+                html: otherUkGradeHtml
+              }
+            }]
+          } | decorateApplicationAttributes(["degree", id, "grade"])) }}
+        {% endif %}
+
+        {{ govukButton({
+          text: "Save and continue"
+        }) }}
+      </div>
     </div>
-  {% endset %}
-
-  {% if international %}
-    <p class="govuk-hint">For example, ‘A’, ‘4.5’, ‘94%’, ‘Distinction’</p>
-    {{ govukRadios({
-      fieldset: {
-        attributes: {
-          "data-module": "clear-hidden"
-        }
-      },
-      items: [{
-        text: "Yes",
-        conditional: {
-          html: internationalGradeHtml
-        }
-      }, {
-        text: "No"
-      }, {
-        text: "I do not know"
-      }]
-    } | decorateApplicationAttributes(["degree", id, "hasGrade"])) }}
-  {% else %}
-    {{ govukRadios({
-      items: [{
-        value: "First-class honours",
-        text: "First-class honours"
-      } if not international, {
-        value: "Upper second-class honours (2:1)",
-        text: "Upper second-class honours (2:1)"
-      } if not international, {
-        value: "Lower second-class honours (2:2)",
-        text: "Lower second-class honours (2:2)"
-      } if not international, {
-        value: "Third-class honours",
-        text: "Third-class honours"
-      } if not international, {
-        text: "Distinction"
-      } if not (undergraduateDegree or international), {
-        text: "Merit"
-      } if not (undergraduateDegree or international), {
-        text: "Pass"
-      } if not international, {
-        text: "Not applicable"
-      } if not undergraduateDegree, {
-        text: "Unknown"
-      } if not undergraduateDegree, {
-        text: "Other",
-        conditional: {
-          html: otherUkGradeHtml
-        }
-      }]
-    } | decorateApplicationAttributes(["degree", id, "grade"])) }}
-  {% endif %}
-
-  {{ govukButton({
-    text: "Save and continue"
-  }) }}
+  </form>
 {% endblock %}
 
 {% if not international %}


### PR DESCRIPTION
Updates following a content review:

* Question changed from "What grade do you think you’ll get" / "Predicted grade" to "What grade do you expect to get?" / "Expected grade"
* The guidance for expected grades has been changed, to make it more relevant to the question being immediately asked.
* Guidance uses hint text rather than inset text, for improved accessibility
* Non-UK version has visible label rather than hidden, using the same question wording as UK version

## Screenshots

### Before

![Before](https://user-images.githubusercontent.com/30665/125968895-d03bdc67-0908-4e57-8526-22db06a19a49.png)

![Before-non-UK](https://user-images.githubusercontent.com/30665/125968908-15e94e93-d3af-4f91-8a00-5c134a814f38.png)

### After

![After](https://user-images.githubusercontent.com/30665/125968932-53f8c8fa-6e51-4d90-9bef-fe4827c0582d.png)

![After-non-UK](https://user-images.githubusercontent.com/30665/125968944-0be7fb59-1186-40b3-bef5-cc086104b15e.png)

