### PR TITLE
Update GCSE question and guidance

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -12,6 +12,19 @@ applicationWhereNotMeetingMinimiumDegreeRequirement.choices.FGHIJ.degreeRequired
 applicationWhereNotMeetingMinimiumDegreeRequirement.choices.ZYXWV.degreeRequired = "third"
 applicationWhereNotMeetingMinimiumDegreeRequirement.degree.abcde.grade = "Third-class honours"
 
+
+applicationWhereStudyingForGcse =  JSON.parse(JSON.stringify(require('./application')))
+
+applicationWhereStudyingForGcse.gcse.english.type = 'not-yet'
+applicationWhereStudyingForGcse.gcse.english.currentlyStudying = 'yes'
+applicationWhereStudyingForGcse.gcse.english.missing = 'I am currently studying for a GCSE English part-time.'
+
+applicationWithNoGcse =  JSON.parse(JSON.stringify(require('./application')))
+
+applicationWithNoGcse.gcse.english.type = 'not-yet'
+applicationWithNoGcse.gcse.english.currentlyStudying = 'no'
+applicationWithNoGcse.gcse.english.missing = 'I have been working in publishing for 10 years, and can demonstrate my English through an equivalency test'
+
 module.exports = {
   applications: {
     12345: require('./application'),
@@ -22,7 +35,9 @@ module.exports = {
     45678: require('./application-single-choice'),
     GLOBE: require('./application-international'),
     21234: internationalApplicationNoRightToStudyYet,
-    52614: applicationWhereNotMeetingMinimiumDegreeRequirement
+    52614: applicationWhereNotMeetingMinimiumDegreeRequirement,
+    21235: applicationWhereStudyingForGcse,
+    21236: applicationWithNoGcse
   },
   findUrl: 'https://www.find-postgraduate-teacher-training.service.gov.uk',
   flags: {

--- a/app/routes/application/gcse.js
+++ b/app/routes/application/gcse.js
@@ -24,7 +24,7 @@ const gcseData = (req) => {
 }
 
 const isInternational = (req) => gcseData(req).type === 'Non-UK qualification'
-const isMissing = (req) => gcseData(req).type === 'I don’t have this qualification yet'
+const isMissing = (req) => gcseData(req).type === 'not-yet'
 const isFailGrade = (req) => {
   const grade = enteredGrade(gcseData(req))
   return gcseData(req).type === 'GCSE' && !passGrades.includes(grade)
@@ -89,8 +89,45 @@ module.exports = router => {
     })
   })
 
+  // Render 'no qualification yet' page
+  router.get('/application/:applicationId/gcse/:id/not-yet', (req, res) => {
+    const { id } = req.params
+
+    res.render('application/gcse/not-yet', {
+      id
+    })
+  })
+
+  // Routing for 'Are you currently studying for an {subject} qualification?'
+  router.post('/application/:applicationId/gcse/:id/not-yet', (req, res) => {
+    const { applicationId, id } = req.params
+
+    const answer = utils.applicationData(req).gcse[id].currentlyStudying
+    let path
+    if (answer == 'yes') {
+      path = `/application/${applicationId}/gcse/${id}/review`
+    } else {
+      path = `/application/${applicationId}/gcse/${id}/equivalency`
+    }
+
+    res.redirect(path)
+  })
+
+
+  // Render equivalency page
+  router.get('/application/:applicationId/gcse/:id/equivalency', (req, res) => {
+    const { applicationId, id } = req.params
+
+    res.render('application/gcse/equivalency', {
+      id
+    })
+  })
+
+
+
   // GCSE type answer branching
   router.post('/application/:applicationId/gcse/:id/answer', (req, res) => {
+
     const { applicationId, id } = req.params
     const { referrer } = req.query
 
@@ -98,7 +135,8 @@ module.exports = router => {
     if (isInternational(req)) {
       path = `/application/${applicationId}/gcse/${id}/country`
     } else if (isMissing(req)) {
-      path = referrer || `/application/${applicationId}/gcse/${id}/review`
+      path = `/application/${applicationId}/gcse/${id}/not-yet`
+      // path = referrer || `/application/${applicationId}/gcse/${id}/review`
     } else {
       path = `/application/${applicationId}/gcse/${id}/grade`
     }

--- a/app/routes/application/gcse.js
+++ b/app/routes/application/gcse.js
@@ -113,6 +113,21 @@ module.exports = router => {
     res.redirect(path)
   })
 
+   // Routing for 'Are you currently retaking your {subject} qualification?'
+  router.post('/application/:applicationId/gcse/:id/currently-retaking', (req, res) => {
+    const { applicationId, id } = req.params
+
+    const answer = utils.applicationData(req).gcse[id].currentlyRetaking
+    let path
+    if (answer == 'yes') {
+      path = `/application/${applicationId}/gcse/${id}/review`
+    } else {
+      path = `/application/${applicationId}/gcse/${id}/equivalency`
+    }
+
+    res.redirect(path)
+  })
+
 
   // Render equivalency page
   router.get('/application/:applicationId/gcse/:id/equivalency', (req, res) => {

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -136,15 +136,15 @@
 {% set gcseRequirements %}
   {% if applicationValue(["gcse", "english", "currentlyStudying"]) == 'yes' %}
     {% if item.acceptsPendingGcses %}
-      Candidates with pending GCSEs will be considered
+      This provider will consider candidates with pending GCSEs
     {% else %}
-      Candidates with pending GCSEs will not be considered
+      This provider does not consider candidates with pending GCSEs
     {% endif %}
   {% else %}
     {% if item.acceptsEquivalencyTests %}
-      Equivalency tests will be accepted in English and maths
+      This provider does will accept equivalency tests in English and maths
     {% else %}
-      Equivalency tests will not be accepted
+      This provider does will accept equivalency tests
     {% endif %}
   {% endif %}
 {% endset %}
@@ -171,7 +171,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>find a course that does {{ "accept pending GCSEs" if  applicationValue(["gcse", "english", "currentlyStudying"]) == 'yes' else "accept equivalency tests"}} </li>
-        <li>contact the provider to see if they will still consider your application</li>
+        <li>contact the provider to see if they’ll still consider your application</li>
       </ul>
 
     {% endset %}

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -159,9 +159,9 @@
         You said
 
         {% if applicationValue(["gcse", "english", "currentlyStudying"]) == 'yes' %}
-          you are currently studying for a qualification in English.
+          you’re currently studying for a qualification in English.
         {% elif applicationValue(["gcse", "english", "currentlyRetaking"]) == 'yes' %}
-          you are currently re-taking a GCSE in English.
+          you’re currently re-taking a GCSE in English.
         {% elif applicationValue(["gcse", "english", "currentlyRetaking"]) == 'no' %}
           you do not have grade 4 (C) or above in GCSE English or an equivalent qualification.
         {% else %}

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -142,9 +142,9 @@
     {% endif %}
   {% else %}
     {% if item.acceptsEquivalencyTests %}
-      This provider does will accept equivalency tests in English and maths
+      This provider will accept equivalency tests in English and maths
     {% else %}
-      This provider does will accept equivalency tests
+      This provider will not accept equivalency tests
     {% endif %}
   {% endif %}
 {% endset %}

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -150,7 +150,7 @@
 {% endset %}
 
 {% set gcseRequirementsHtml %}
-  {% if applicationValue(["gcse", "english", "type"]) == "not-yet" %}
+  {% if applicationValue(["gcse", "english", "type"]) == "not-yet" or applicationValue(["gcse", "english", "currentlyRetaking"]) %}
 
     {% set gcseRequirementsWarningHtml %}
       <p class="govuk-heading-s app-inset-text__title">{{ gcseRequirements }}</p>
@@ -159,13 +159,15 @@
         You said
 
         {% if applicationValue(["gcse", "english", "currentlyStudying"]) == 'yes' %}
-          you are currently studying for an
+          you are currently studying for a qualification in English.
+        {% elif applicationValue(["gcse", "english", "currentlyRetaking"]) == 'yes' %}
+          you are currently re-taking a GCSE in English.
+        {% elif applicationValue(["gcse", "english", "currentlyRetaking"]) == 'no' %}
+          you do not have grade 4 (C) or above in GCSE English or an equivalent qualification.
         {% else %}
-          you do not have an
+          you do not have a qualification in English.
         {% endif %}
-
-        English qualification
-      .</p>
+      </p>
 
       <p class="govuk-body">You can:</p>
 

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -132,6 +132,62 @@
   {% endif %}
 {% endset %}
 
+
+{% set gcseRequirements %}
+  {% if applicationValue(["gcse", "english", "currentlyStudying"]) == 'yes' %}
+    {% if item.acceptsPendingGcses %}
+      Candidates with pending GCSEs will be considered
+    {% else %}
+      Candidates with pending GCSEs will not be considered
+    {% endif %}
+  {% else %}
+    {% if item.acceptsEquivalencyTests %}
+      Equivalency tests will be accepted in English and maths
+    {% else %}
+      Equivalency tests will not be accepted
+    {% endif %}
+  {% endif %}
+{% endset %}
+
+{% set gcseRequirementsHtml %}
+  {% if applicationValue(["gcse", "english", "type"]) == "not-yet" %}
+
+    {% set gcseRequirementsWarningHtml %}
+      <p class="govuk-heading-s app-inset-text__title">{{ gcseRequirements }}</p>
+
+      <p class="govuk-body">
+        You said
+
+        {% if applicationValue(["gcse", "english", "currentlyStudying"]) == 'yes' %}
+          you are currently studying for an
+        {% else %}
+          you do not have an
+        {% endif %}
+
+        English qualification
+      .</p>
+
+      <p class="govuk-body">You can:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>find a course that does {{ "accept pending GCSEs" if  applicationValue(["gcse", "english", "currentlyStudying"]) == 'yes' else "accept equivalency tests"}} </li>
+        <li>contact the provider to see if they will still consider your application</li>
+      </ul>
+
+    {% endset %}
+
+
+    {{ govukInsetText({
+      html: gcseRequirementsWarningHtml,
+      classes: "app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1"
+    })}}
+
+  {% else %}
+    {{ gcseRequirements }}
+  {% endif %}
+
+{% endset %}
+
 {{ govukSummaryList({
   rows: [{
     key: {
@@ -199,6 +255,14 @@
       classes: "app-summary-list__value--wide"
     }
   } if (data.applications[applicationId].candidate.residencyDisclose == "I will need to apply for permission to work or study in the UK"), {
+    key: {
+      text: "GCSE requirements"
+    },
+    value: {
+      html: gcseRequirementsHtml,
+      classes: "app-summary-list__value--wide"
+    }
+  }, {
     key: {
       text: "Status"
     },

--- a/app/views/_includes/item/gcse.njk
+++ b/app/views/_includes/item/gcse.njk
@@ -1,6 +1,7 @@
 {% set item = applicationValue(["gcse", id]) %}
-{% set missing = item.type == "I don’t have this qualification yet" %}
+{% set missingGcse = item.type == "not-yet" %}
 {% set nonUK = item.type == "Non-UK qualification" %}
+{% set subject = (id | capitalize) if id == "english" else id %}
 
 {% set qualificationText -%}
   {%- if item.typeUk or item.typeNonUk or item.type %}
@@ -41,11 +42,34 @@
   {% set gradeHtml = item.gradeOther or item.grade %}
 {% endif %}
 
-{% if missing %}
+{% if missingGcse %}
+
   {{ govukSummaryList({
     rows: [{
+      key: { text: "What type of " + subject + " qualification do you have?" },
+      value: { text: "I don’t have a " + subject + " qualification yet" },
+      actions: {
+        items: [{
+          href: applicationPath + "/gcse/" + id + "?referrer=" + referrer,
+          text: "Change",
+          visuallyHiddenText: "whether you have this qualification"
+        }]
+      } if canAmend
+    },
+    {
+      key: { text: "Are you currently studying for this qualification?" },
+      value: { text: (item.currentlyStudying | capitalize) },
+      actions: {
+        items: [{
+          href: applicationPath + "/gcse/" + id + "/not-yet",
+          text: "Change",
+          visuallyHiddenText: "whether you are studying for this qualification"
+        }]
+      } if canAmend
+    },
+    {
       key: {
-        text: "How I expect to gain this qualification"
+        text: ("How I expect to gain this qualification" if item.currentlyStudying == "yes" else "Evidence I have the the skills at the required standard")
       },
       value: {
         html: (item.missing or "No reason given") | nl2br | safe

--- a/app/views/_includes/item/gcse.njk
+++ b/app/views/_includes/item/gcse.njk
@@ -76,7 +76,7 @@
       },
       actions: {
         items: [{
-          href: applicationPath + "/gcse/" + id + "?referrer=" + referrer,
+          href: applicationPath + "/gcse/" + id + "/no-pass-grade?referrer=" + referrer,
           text: "Change",
           visuallyHiddenText: "year"
         }]

--- a/app/views/_includes/item/gcse.njk
+++ b/app/views/_includes/item/gcse.njk
@@ -56,11 +56,7 @@
 
 {% set currentlyRetakingHtml %}
   {% if item.currentlyRetaking == 'yes' %}
-    {% if item.currentlyRetakingDetails %}
-      {{ item.currentlyRetakingDetails | nl2br | safe }}
-    {% else %}
-      Yes
-    {% endif %}
+    Yes
   {% else %}
     No
   {% endif %}

--- a/app/views/_includes/item/gcse.njk
+++ b/app/views/_includes/item/gcse.njk
@@ -100,7 +100,7 @@
           visuallyHiddenText: "explanation"
         }]
       } if canAmend
-    }
+    } if (item.currentlyStudying == 'no')
     ]
   }) }}
 {% else %}

--- a/app/views/_includes/item/gcse.njk
+++ b/app/views/_includes/item/gcse.njk
@@ -42,6 +42,30 @@
   {% set gradeHtml = item.gradeOther or item.grade %}
 {% endif %}
 
+{% set currentlyStudyingHtml %}
+  {% if item.currentlyStudying == 'yes' %}
+    {% if item.currentlyStudyingDetails %}
+      {{ item.currentlyStudyingDetails | nl2br | safe }}
+    {% else %}
+      Yes
+    {% endif %}
+  {% else %}
+    No
+  {% endif %}
+{% endset %}
+
+{% set currentlyRetakingHtml %}
+  {% if item.currentlyRetaking == 'yes' %}
+    {% if item.currentlyRetakingDetails %}
+      {{ item.currentlyRetakingDetails | nl2br | safe }}
+    {% else %}
+      Yes
+    {% endif %}
+  {% else %}
+    No
+  {% endif %}
+{% endset %}
+
 {% if missingGcse %}
 
   {{ govukSummaryList({
@@ -58,7 +82,7 @@
     },
     {
       key: { text: "Are you currently studying for this qualification?" },
-      value: { text: (item.currentlyStudying | capitalize) },
+      value: { html: currentlyStudyingHtml },
       actions: {
         items: [{
           href: applicationPath + "/gcse/" + id + "/not-yet",
@@ -66,22 +90,22 @@
           visuallyHiddenText: "whether you are studying for this qualification"
         }]
       } if canAmend
-    },
-    {
+    }, {
       key: {
-        text: ("How I expect to gain this qualification" if item.currentlyStudying == "yes" else "Evidence I have the the skills at the required standard")
+        text: "Other evidence I have the skills required"
       },
       value: {
-        html: (item.missing or "No reason given") | nl2br | safe
+        html: (item.otherEvidence or "Not provided") | nl2br | safe
       },
       actions: {
         items: [{
-          href: applicationPath + "/gcse/" + id + "/no-pass-grade?referrer=" + referrer,
+          href: applicationPath + "/gcse/" + id + "/equivalency?referrer=" + referrer,
           text: "Change",
-          visuallyHiddenText: "year"
+          visuallyHiddenText: "explanation"
         }]
       } if canAmend
-    }]
+    }
+    ]
   }) }}
 {% else %}
   {{ govukSummaryList({
@@ -183,20 +207,31 @@
           visuallyHiddenText: "year"
         }]
       } if canAmend
+    },
+    {
+      key: { text: "Are you currently studying to re-take this qualification?" },
+      value: { html: currentlyRetakingHtml },
+      actions: {
+        items: [{
+          href: applicationPath + "/gcse/" + id + "/no-pass-grade",
+          text: "Change",
+          visuallyHiddenText: "whether you are re-taking this qualification"
+        }]
+      } if canAmend
     }, {
       key: {
-        text: "How I meet the requirement for grade 4 (C) or above"
+        text: "Other evidence I have the skills required"
       },
       value: {
-        html: (item.missing or "No reason given") | nl2br | safe
+        html: (item.otherEvidence or "Not provided") | nl2br | safe
       },
       actions: {
         items: [{
-          href: applicationPath + "/gcse/" + id + "/no-pass-grade?referrer=" + referrer,
+          href: applicationPath + "/gcse/" + id + "/equivalency?referrer=" + referrer,
           text: "Change",
           visuallyHiddenText: "explanation"
         }]
       } if canAmend
-    } if item.missing and not hasElligibleGrade]
+    } if item.currentlyRetaking == 'no']
   }) }}
 {% endif %}

--- a/app/views/admin/states.njk
+++ b/app/views/admin/states.njk
@@ -111,6 +111,14 @@
 
     <dt><a href="/application/21234">Does not yet have right to work in the UK, applying to a course which can sponsor a visa</a></dt>
     <dd>The candidate will see some guidance</dd>
+
+
+    <dt><a href="/application/21235">Currently studying for a GCSE, applying for a course which does not accept pending GCSEs</a></dt>
+    <dd>The candidate will see some guidance</dd>
+
+    <dt><a href="/application/21236">Does not have a GCSE, applying for course which does not offer equivalency tests</a></dt>
+    <dd>The candidate will see some guidance</dd>
+
   </dl>
 
 

--- a/app/views/application/gcse/equivalency.njk
+++ b/app/views/application/gcse/equivalency.njk
@@ -26,7 +26,7 @@
     },
     maxwords: 200,
     rows: 6
-  } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
+  } | decorateApplicationAttributes(["gcse", id, "otherEvidence"])) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/gcse/equivalency.njk
+++ b/app/views/application/gcse/equivalency.njk
@@ -8,7 +8,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: referrer or paths.back
+    href: referrer or "/application/" + applicationId + "/gcse/" + id + "/not-yet"
   }) }}
 {% endblock %}
 

--- a/app/views/application/gcse/equivalency.njk
+++ b/app/views/application/gcse/equivalency.njk
@@ -1,0 +1,34 @@
+{% extends "_form.njk" %}
+
+{% set subject = (id | capitalize) if id == "english" else id %}
+{% set title = "Your " + subject + " needs to be at the standard of GCSE grade 4 (C) or above, or equivalent" %}
+{% set allowsFeedback = true %}
+{% set formaction = "/application/" + applicationId + "/gcse/" + id + "/review" %}
+
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: referrer or paths.back
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  <p class="govuk-body">You can still apply for teacher training if you do not have a qualification which demonstrates this.</p>
+
+  <p class="govuk-body">Some providers may let you sit an equivalency test to show you have the required skills.</p>
+
+  <p class="govuk-body">For advice, contact your chosen training provider or <a href="https://getintoteaching.education.gov.uk/">Get Into Teaching</a>.</p>
+
+  {{ govukCharacterCount({
+    label: {
+      classes: "govuk-label--m",
+      html: "If you have other evidence of having " + subject + " skills at the required standard, give details (optional)"
+    },
+    maxwords: 200,
+    rows: 6
+  } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
+
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+{% endblock %}

--- a/app/views/application/gcse/equivalency.njk
+++ b/app/views/application/gcse/equivalency.njk
@@ -17,7 +17,7 @@
 
   <p class="govuk-body">Some providers may let you sit an equivalency test to show you have the required skills.</p>
 
-  <p class="govuk-body">For advice, contact your chosen training provider or <a href="https://getintoteaching.education.gov.uk/">Get Into Teaching</a>.</p>
+  <p class="govuk-body">For advice, contact your chosen training provider or a <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">teacher training adviser</a>.</p>
 
   {{ govukCharacterCount({
     label: {

--- a/app/views/application/gcse/equivalency.njk
+++ b/app/views/application/gcse/equivalency.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set subject = (id | capitalize) if id == "english" else id %}
-{% set title = "Your " + subject + " needs to be at the standard of GCSE grade 4 (C) or above, or equivalent" %}
+{% set title = "You need a GCSE in " + subject + " at grade 4 (C) or above, or equivalent" %}
 {% set allowsFeedback = true %}
 {% set formaction = "/application/" + applicationId + "/gcse/" + id + "/review" %}
 

--- a/app/views/application/gcse/grade.njk
+++ b/app/views/application/gcse/grade.njk
@@ -3,9 +3,9 @@
 {% set subject = (id | capitalize) if id == "english" else id %}
 {% set type = applicationValue(["gcse", id, "type"]) %}
 {% if type == "GCSE" and id == "english" %}
-  {% set title = "What English GCSE did you do?" %}
+  {% set title = "Which English GCSE did you do?" %}
 {% elif type == "GCSE" and id == "science" %}
-  {% set title = "What science GCSEs did you do?" %}
+  {% set title = "Which science GCSEs did you do?" %}
 {% elif type == "GCSE" or type == "O level" or type == "Scottish National 5" %}
   {% set title = "What grade is your " + subject + " " + type + "?" %}
 {% else %}

--- a/app/views/application/gcse/grade.njk
+++ b/app/views/application/gcse/grade.njk
@@ -3,7 +3,7 @@
 {% set subject = (id | capitalize) if id == "english" else id %}
 {% set type = applicationValue(["gcse", id, "type"]) %}
 {% if type == "GCSE" and id == "english" %}
-  {% set title = "Which English GCSE did you do?" %}
+  {% set title = "Which GCSEs in English do you have?" %}
 {% elif type == "GCSE" and id == "science" %}
   {% set title = "Which science GCSEs did you do?" %}
 {% elif type == "GCSE" or type == "O level" or type == "Scottish National 5" %}
@@ -135,14 +135,7 @@
         }]
       } | decorateApplicationAttributes(["gcse", id, "exam"])) }}
     {% elif id == "english" %}
-      <p class="govuk-body">An English Language GCSE is preferred.</p>
       {{ govukCheckboxes({
-        fieldset: {
-          legend: {
-            classes: "govuk-fieldset__legend--m",
-            text: "Select the GCSE(s) you did and include your grade"
-          }
-        },
         items: [{
           value: "English",
           text: "English",
@@ -178,8 +171,8 @@
             })
           }
         }, {
-          value: "Other English subject",
-          text: "Other English subject",
+          value: "Another English subject",
+          text: "Another English subject",
           conditional: {
             html: otherEnglishSubjectHtml
           }

--- a/app/views/application/gcse/index.njk
+++ b/app/views/application/gcse/index.njk
@@ -1,4 +1,4 @@
-{% extends "_form.njk" %}
+{% extends "_layout.njk" %}
 
 {% set action = "edit" if applicationValue(["gcse", id, "type"]) else "add" %}
 {% set subject = (id | capitalize) if id == "english" else id %}
@@ -18,76 +18,82 @@
   {% endif %}
 {% endblock %}
 
-{% block primary %}
-  {% set otherUkConditionalHtml %}
-    {{ govukInput({
-      label: {
-        text: "Enter type of qualification"
-      }
-    } | decorateApplicationAttributes(["gcse", id, "typeUk"])) }}
-  {% endset %}
+{% block content %}
+  <form{% if formaction %} action="{{ formaction }}"{% endif %} method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
 
-  {% set nonUkConditionalHtml %}
-    {{ govukInput({
-      label: {
-        text: "Enter type of qualification"
-      },
-      hint: {
-        html: "For example, High school diploma, Higher Secondary School Certificate, <span lang=\"fr\">Baccalauréat Général</span>, <span lang=\"es\">Título de Bachiller</span>"
-      }
-    } | decorateApplicationAttributes(["gcse", id, "typeNonUk"])) }}
-  {% endset %}
+        {% set otherUkConditionalHtml %}
+          {{ govukInput({
+            label: {
+              text: "Enter type of qualification"
+            }
+          } | decorateApplicationAttributes(["gcse", id, "typeUk"])) }}
+        {% endset %}
 
-  {% set missingConditionalHtml %}
-    <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, it will need to be in place by the start of your course.</p>
-    <p class="govuk-hint">For advice, contact your chosen training provider or <a href="https://getintoteaching.education.gov.uk/get-help-and-support/">Get Into Teaching</a>.</p>
-    {{ govukCharacterCount({
-      label: {
-        classes: "govuk-label--s",
-        html: "If you are working towards this qualification, give us details (optional)"
-      },
-      maxwords: 200,
-      rows: 12
-    } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
-  {% endset -%}
+        {% set nonUkConditionalHtml %}
+          {{ govukInput({
+            label: {
+              text: "Enter type of qualification"
+            },
+            hint: {
+              html: "For example, High school diploma, Higher Secondary School Certificate, <span lang=\"fr\">Baccalauréat Général</span>, <span lang=\"es\">Título de Bachiller</span>"
+            }
+          } | decorateApplicationAttributes(["gcse", id, "typeNonUk"])) }}
+        {% endset %}
 
-  {{ govukRadios({
-    fieldset: {
-      legend: {
-        text: "What type of qualification do you want to add?",
-        classes: "govuk-label--m"
-      },
-      attributes: {
-        "data-module": "clear-hidden"
-      }
-    },
-    items: [{
-      text: "GCSE"
-    }, {
-      text: "O level"
-    }, {
-      text: "Scottish National 5"
-    }, {
-      text: "Other UK qualification",
-      conditional: {
-        html: otherUkConditionalHtml
-      }
-    }, {
-      text: "Non-UK qualification",
-      conditional: {
-        html: nonUkConditionalHtml
-      }
-    }, {
-      divider: "or"
-    }, {
-      text: "I don’t have this qualification yet",
-      conditional: {
-        html: missingConditionalHtml
-      }
-    }]
-  } | decorateApplicationAttributes(["gcse", id, "type"])) }}
+        {% set missingConditionalHtml %}
+          <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, it will need to be in place by the start of your course.</p>
+          <p class="govuk-hint">For advice, contact your chosen training provider or <a href="https://getintoteaching.education.gov.uk/get-help-and-support/">Get Into Teaching</a>.</p>
+          {{ govukCharacterCount({
+            label: {
+              classes: "govuk-label--s",
+              html: "If you are working towards this qualification, give us details (optional)"
+            },
+            maxwords: 200,
+            rows: 12
+          } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
+        {% endset -%}
 
-  {{ govukButton({
-    text: "Save and continue"
-  }) }}
+        {{ govukRadios({
+          fieldset: {
+            legend: {
+              text: "What type of " + subject + " qualification do you have?",
+              classes: "govuk-label--l",
+              isPageTitle: true
+            },
+            attributes: {
+              "data-module": "clear-hidden"
+            }
+          },
+          items: [{
+            text: "GCSE"
+          }, {
+            text: "O level"
+          }, {
+            text: "Scottish National 5"
+          }, {
+            text: "Other UK qualification",
+            conditional: {
+              html: otherUkConditionalHtml
+            }
+          }, {
+            text: "Non-UK qualification",
+            conditional: {
+              html: nonUkConditionalHtml
+            }
+          }, {
+            divider: "or"
+          }, {
+            text: "I don’t have a " + subject + " qualification yet",
+            value: "not-yet"
+          }]
+        } | decorateApplicationAttributes(["gcse", id, "type"])) }}
+
+        {{ govukButton({
+          text: "Save and continue"
+        }) }}
+      </div>
+    </div>
+  </form>
 {% endblock %}

--- a/app/views/application/gcse/index.njk
+++ b/app/views/application/gcse/index.njk
@@ -26,7 +26,7 @@
         {% set otherUkConditionalHtml %}
           {{ govukInput({
             label: {
-              text: "Enter type of qualification"
+              text: "Type of qualification"
             }
           } | decorateApplicationAttributes(["gcse", id, "typeUk"])) }}
         {% endset %}
@@ -34,7 +34,7 @@
         {% set nonUkConditionalHtml %}
           {{ govukInput({
             label: {
-              text: "Enter type of qualification"
+              text: "Type of qualification"
             },
             hint: {
               html: "For example, High school diploma, Higher Secondary School Certificate, <span lang=\"fr\">Baccalauréat Général</span>, <span lang=\"es\">Título de Bachiller</span>"
@@ -58,7 +58,7 @@
         {{ govukRadios({
           fieldset: {
             legend: {
-              text: "What type of " + subject + " qualification do you have?",
+              text: "What type of qualification in " + subject + " do you have?",
               classes: "govuk-label--l",
               isPageTitle: true
             },
@@ -73,19 +73,19 @@
           }, {
             text: "Scottish National 5"
           }, {
-            text: "Other UK qualification",
+            text: "Another UK qualification",
             conditional: {
               html: otherUkConditionalHtml
             }
           }, {
-            text: "Non-UK qualification",
+            text: "A non-UK qualification",
             conditional: {
               html: nonUkConditionalHtml
             }
           }, {
             divider: "or"
           }, {
-            text: "I don’t have a " + subject + " qualification yet",
+            text: "I don’t have " + ("an " + subject if subject == 'English' else 'a ' + subject) + " qualification yet",
             value: "not-yet"
           }]
         } | decorateApplicationAttributes(["gcse", id, "type"])) }}

--- a/app/views/application/gcse/no-pass-grade.njk
+++ b/app/views/application/gcse/no-pass-grade.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set subject = (id | capitalize) if id == "english" else id %}
-{% set title = "You need a " + subject + " GCSE at grade 4 (C) or above, or equivalent" %}
+{% set title = "You need GCSE in " + subject + " at grade 4 (C) or above, or equivalent" %}
 {% set allowsFeedback = true %}
 
 {% block pageNavigation %}

--- a/app/views/application/gcse/no-pass-grade.njk
+++ b/app/views/application/gcse/no-pass-grade.njk
@@ -3,6 +3,7 @@
 {% set subject = (id | capitalize) if id == "english" else id %}
 {% set title = "You need a GCSE in " + subject + " at grade 4 (C) or above, or equivalent" %}
 {% set allowsFeedback = true %}
+{% set formaction = "/application/" + applicationId + "/gcse/" + id + "/currently-retaking" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -23,7 +24,7 @@
         },
         maxwords: 200,
         rows: 6
-      } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
+      } | decorateApplicationAttributes(["gcse", id, "currentlyRetakingDetails"])) }}
   {% endset %}
 
   {{ govukRadios({
@@ -43,7 +44,7 @@
       text: "No",
       value: "no"
     }
-    ]} | decorateApplicationAttributes(["gcse", id, "currentlyStudying"])) }}
+    ]} | decorateApplicationAttributes(["gcse", id, "currentlyRetaking"])) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/gcse/no-pass-grade.njk
+++ b/app/views/application/gcse/no-pass-grade.njk
@@ -16,17 +16,6 @@
 
   <p class="govuk-body">For advice, speak to a <a href="https://adviser-getintoteaching.education.gov.uk">teacher training adviser</a>.</p>
 
-  {% set studyingForQualificationHtml %}
-    {{ govukCharacterCount({
-        label: {
-          classes: "govuk-label--s",
-          html: "Details of the qualification you are studying for"
-        },
-        maxwords: 200,
-        rows: 6
-      } | decorateApplicationAttributes(["gcse", id, "currentlyRetakingDetails"])) }}
-  {% endset %}
-
   {{ govukRadios({
     fieldset: {
       legend: {
@@ -37,8 +26,8 @@
     items: [{
       text: "Yes",
       value: "yes",
-      conditional: {
-        html: studyingForQualificationHtml
+      hint: {
+        text: "This must be completed before you start your teacher training course."
       }
     }, {
       text: "No",

--- a/app/views/application/gcse/no-pass-grade.njk
+++ b/app/views/application/gcse/no-pass-grade.njk
@@ -11,17 +11,39 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">You can still apply for teacher training if you do not have this. However, it will need to be in place by the start of your course.</p>
-  <p class="govuk-body">For advice, contact your chosen training provider or <a href="https://getintoteaching.education.gov.uk/">Get Into Teaching</a>.</p>
+  <p class="govuk-body">You can still apply for teacher training if you do not have this. Providers may allow you to sit an equivalency test, or you can re-take your GCSE.</p>
 
-  {{ govukCharacterCount({
-    label: {
-      classes: "govuk-label--m",
-      html: "If you are working towards this qualification at grade 4 (C) or above, give us details (optional)"
+  <p class="govuk-body">For advice, speak to a <a href="https://adviser-getintoteaching.education.gov.uk">teacher training adviser</a>.</p>
+
+  {% set studyingForQualificationHtml %}
+    {{ govukCharacterCount({
+        label: {
+          classes: "govuk-label--s",
+          html: "Details of the qualification you are studying for"
+        },
+        maxwords: 200,
+        rows: 6
+      } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
+  {% endset %}
+
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "Are you currently studying to re-take your GCSE in " + subject + "?",
+        classes: "govuk-fieldset__legend--m"
+      }
     },
-    maxwords: 200,
-    rows: 6
-  } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
+    items: [{
+      text: "Yes",
+      value: "yes",
+      conditional: {
+        html: studyingForQualificationHtml
+      }
+    }, {
+      text: "No",
+      value: "no"
+    }
+    ]} | decorateApplicationAttributes(["gcse", id, "currentlyStudying"])) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/gcse/no-pass-grade.njk
+++ b/app/views/application/gcse/no-pass-grade.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set subject = (id | capitalize) if id == "english" else id %}
-{% set title = "You need GCSE in " + subject + " at grade 4 (C) or above, or equivalent" %}
+{% set title = "You need a GCSE in " + subject + " at grade 4 (C) or above, or equivalent" %}
 {% set allowsFeedback = true %}
 
 {% block pageNavigation %}

--- a/app/views/application/gcse/not-yet.njk
+++ b/app/views/application/gcse/not-yet.njk
@@ -22,7 +22,7 @@
         },
         maxwords: 200,
         rows: 6
-      } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
+      } | decorateApplicationAttributes(["gcse", id, "currentlyStudyingDetails"])) }}
   {% endset %}
 
   {{ govukRadios({

--- a/app/views/application/gcse/not-yet.njk
+++ b/app/views/application/gcse/not-yet.njk
@@ -1,0 +1,45 @@
+{% extends "_form.njk" %}
+
+{% set subject = ("an " + id | capitalize) if id == "english" else "a " + id %}
+{% set type = applicationValue(["gcse", id, "type"]) %}
+{% set title = "Are you currently studying for " + subject + " qualification?" %}
+{% set allowsFeedback = true %}
+{% set formaction = "/application/" + applicationId + "/gcse/" + id + "/not-yet" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/application/" + applicationId + "/gcse/" + id
+  }) }}
+{% endblock %}
+
+{% block primary %}
+
+  {% set studyingForQualificationHtml %}
+    {{ govukCharacterCount({
+        label: {
+          classes: "govuk-label--s",
+          html: "Details of the qualification you are studying for"
+        },
+        maxwords: 200,
+        rows: 6
+      } | decorateApplicationAttributes(["gcse", id, "missing"])) }}
+  {% endset %}
+
+  {{ govukRadios({
+
+    items: [{
+      text: "Yes",
+      value: "yes",
+      conditional: {
+        html: studyingForQualificationHtml
+      }
+    }, {
+      text: "No",
+      value: "no"
+    }
+    ]} | decorateApplicationAttributes(["gcse", id, "currentlyStudying"])) }}
+
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+{% endblock %}

--- a/app/views/application/gcse/not-yet.njk
+++ b/app/views/application/gcse/not-yet.njk
@@ -18,7 +18,7 @@
     {{ govukCharacterCount({
         label: {
           classes: "govuk-label--s",
-          html: "Details of the qualification you are studying for"
+          html: "Details of the qualification you’re studying for"
         },
         maxwords: 200,
         rows: 6

--- a/app/views/application/gcse/not-yet.njk
+++ b/app/views/application/gcse/not-yet.njk
@@ -2,7 +2,7 @@
 
 {% set subject = ("an " + id | capitalize) if id == "english" else "a " + id %}
 {% set type = applicationValue(["gcse", id, "type"]) %}
-{% set title = "Are you currently studying for " + subject + " qualification?" %}
+{% set title = "Are you currently studying for a GCSE in " + subject + ", or equivalent?" %}
 {% set allowsFeedback = true %}
 {% set formaction = "/application/" + applicationId + "/gcse/" + id + "/not-yet" %}
 

--- a/app/views/application/gcse/year.njk
+++ b/app/views/application/gcse/year.njk
@@ -1,10 +1,10 @@
-{% extends "_form.njk" %}
+{% extends "_layout.njk" %}
 
 {% set subject = (id | capitalize) if id == "english" else id %}
 {% if applicationValue(["gcse", id, "completed"]) == "false" %}
   {% set title = "When will you get your " + subject + " qualification?" %}
 {% else %}
-  {% set title = "When was your " + subject + " qualification awarded?" %}
+  {% set title = "What year did you get your " + subject + " qualification?" %}
 {% endif %}
 {% set allowsFeedback = true %}
 
@@ -14,19 +14,27 @@
   }) }}
 {% endblock %}
 
-{% block primary %}
-  {{ govukInput({
-    label: {
-      classes: "govuk-label--m",
-      text: "Enter year"
-    },
-    hint: {
-      text: "For example, 1996"
-    },
-    classes: "govuk-input--width-4"
-  } | decorateApplicationAttributes(["gcse", id, "year"])) }}
 
-  {{ govukButton({
-    text: "Save and continue"
-  }) }}
+{% block content %}
+  <form{% if formaction %} action="{{ formaction }}"{% endif %} method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+          {{ govukInput({
+            label: {
+              classes: "govuk-label--xl",
+              text: title
+            },
+            hint: {
+              text: "For example, 1996"
+            },
+            classes: "govuk-input--width-4"
+          } | decorateApplicationAttributes(["gcse", id, "year"])) }}
+
+          {{ govukButton({
+            text: "Save and continue"
+          }) }}
+        </div>
+      </div>
+    </form>
 {% endblock %}


### PR DESCRIPTION
This aims to give candidates some guidance (or warnings) in the scenario that they:

* are currently (re)taking a GCSE, but are applying to a course which does not accept pending GCSE
* do not have a GCSE C or above and are not currently studying for one, and are applying for a course which does not accept equivalency tests

We also reviewed the content of the existing GCSE pages.

The initial GCSE question has been simplified, to remove reference to the C/4 grade, as this is caught later:

<img width="770" alt="Screenshot 2021-07-23 at 09 21 00" src="https://user-images.githubusercontent.com/30665/126755641-e1301371-5435-4dd7-8afc-3f8777111186.png">

If the candidates have a GCSE in English, the following page has been simplified, with the reference to English language as being preferred removed:

<img width="729" alt="Screenshot 2021-07-26 at 15 44 14" src="https://user-images.githubusercontent.com/30665/127008747-0e8c66c6-b267-47b4-98bb-d369a0021120.png">

If candidates select that they do not yet have this qualification, they get asked if they are currently studying for one:

<img width="802" alt="Screenshot 2021-07-19 at 17 34 09" src="https://user-images.githubusercontent.com/30665/126195132-3d494e0b-ab6d-4722-9fca-8e3f084b2856.png">

If they say yes, they can give details, as before:

<img width="803" alt="Screenshot 2021-07-19 at 17 34 50" src="https://user-images.githubusercontent.com/30665/126195217-b4018783-0029-44a9-a3d8-b5d625606d44.png">

If they say no, they are show some guidance, and offered the chance to explain how they otherwise meet the standard:

<img width="788" alt="Screenshot 2021-07-19 at 17 35 38" src="https://user-images.githubusercontent.com/30665/126195317-47fba80b-618f-4438-9eab-ef18ff8cb4c0.png">

If they DO have a GCSE, but the grade is D / 3 or below, then they are asked this follow-up question:

<img width="794" alt="Screenshot 2021-07-26 at 15 45 48" src="https://user-images.githubusercontent.com/30665/127009008-e7134ee0-c6ee-4bd5-9a99-29a1511f5001.png">

(If they say Yes, they can give details in a revealed textarea)

Depending on these answers, some guidance is shown in the Course Choice review pages:

<img width="649" alt="Screenshot 2021-07-19 at 17 36 18" src="https://user-images.githubusercontent.com/30665/126195400-9d9c5fd4-5643-473d-b092-5def4862865a.png">


or

<img width="680" alt="Screenshot 2021-07-19 at 17 37 10" src="https://user-images.githubusercontent.com/30665/126195514-f020f96b-71e5-41ee-920c-1d345fef4940.png">
