### PR TITLE
Half-update references section, minus selection flow

### DIFF
--- a/app/assets/sass/components/_status-indicator.scss
+++ b/app/assets/sass/components/_status-indicator.scss
@@ -1,45 +1,50 @@
 .app-status-indicator {
   align-items: center;
+  border: 4px currentColor solid;
   border-radius: 100%;
   display: inline-flex;
-  height: govuk-spacing(2);
+  height: govuk-spacing(1);
   justify-content: center;
-  width: govuk-spacing(2);
+  width: govuk-spacing(1);
   margin-right: govuk-spacing(1);
 }
 
+.app-status-indicator--filled {
+  background-color: currentColor;
+}
+
 .app-status-indicator--grey {
-  background-color: govuk-colour("mid-grey");
+  color: govuk-colour("mid-grey");
 }
 
 .app-status-indicator--purple {
-  background-color: govuk-colour("purple");
+  color: govuk-colour("purple");
 }
 
 .app-status-indicator--turquoise {
-  background-color: govuk-colour("turquoise");
+  color: govuk-colour("turquoise");
 }
 
 .app-status-indicator--blue {
-  background-color: govuk-colour("blue");
+  color: govuk-colour("blue");
 }
 
 .app-status-indicator--yellow {
-  background-color: govuk-colour("yellow");
+  color: govuk-colour("yellow");
 }
 
 .app-status-indicator--orange {
-  background-color: govuk-colour("orange");
+  color: govuk-colour("orange");
 }
 
 .app-status-indicator--red {
-  background-color: govuk-colour("red");
+  color: govuk-colour("red");
 }
 
 .app-status-indicator--pink {
-  background-color: govuk-colour("pink");
+  color: govuk-colour("pink");
 }
 
 .app-status-indicator--green {
-  background-color: govuk-colour("green");
+  color: govuk-colour("green");
 }

--- a/app/data/application.js
+++ b/app/data/application.js
@@ -67,7 +67,7 @@ module.exports = {
       relationship: 'They were my tutor at university from 2011 to 2013',
       email: 'joesph.r.bloggs@example.com',
       type: 'Academic',
-      status: 'Reference given',
+      status: 'Reference selected',
       ready: true,
       log: [{
         note: 'Request sent',
@@ -105,7 +105,7 @@ module.exports = {
       relationship: 'They were my tutor at university from 2011 to 2013',
       email: 'james.m@example.com',
       type: 'Academic',
-      status: 'Reference given',
+      status: 'Reference selected',
       ready: true,
       nudges: 0,
       log: [{
@@ -140,7 +140,7 @@ module.exports = {
   },
   additionalSupportDisclose: 'No',
   safeguardingDisclose: 'No',
-  test: "test",
+  test: 'test',
   degree: {
     abcde: {
       id: 'kq19m',

--- a/app/filters.js
+++ b/app/filters.js
@@ -259,6 +259,8 @@ module.exports = (env) => {
         return `${prefix}--yellow`
       case 'Reference given':
         return `${prefix}--green`
+      case 'Reference selected':
+        return `${prefix}--green ${prefix}--filled`
       case 'Request cancelled':
         return `${prefix}--orange`
       case 'Reference declined':

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -135,45 +135,45 @@
     <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
     {% set references = applicationValue(["references"]) | toArray %}
     {% set readyReferences = references | selectattr("ready") | reverse %}
-    {% set referencesContent %}
-      <ul class="govuk-list">
-      {% for reference in references %}
-        <li class="govuk-body-s"><span class="app-status-indicator {{ reference.status | statusClass("app-status-indicator") }}"></span> <b>{{ reference.name }}</b>: {{ reference.status }}</li>
-      {% endfor %}
-      </ul>
-    {% endset %}
 
     {% if readyReferences | length >= 2 %}
-      {% set referencesItemText = "Review your references" %}
+      {% set referencesItemText = "Reference requests" %}
       {% set referencesTagText = completedTagText %}
       {% set referencesTagClass = tagClass %}
-      {% set showReferencesContent = true %}
+      <!--p class="govuk-body govuk-!-margin-bottom-2">You have enough references to send your application to training providers.</p>
+      <p class="govuk-body">Select the 2 references you want to include in your application.</p-->
     {% else %}
-      <p class="govuk-body govuk-!-margin-bottom-2">You have to get 2 references back before you can send your application to training providers.</p>
-      <p class="govuk-body">It takes 8 days to get a reference on average.</p>
-      {% if references | length > 0 %}
-        {% set referencesItemText = "Manage your references" %}
-        {% set referencesTagText = inprogressTagText %}
-        {% set referencesTagClass = inprogressTagClass %}
-        {% set showReferencesContent = true %}
-      {% else %}
-        {% set referencesItemText = "Add your references" %}
-        {% set referencesTagText = incompleteTagText %}
-        {% set referencesTagClass = incompleteTagClass %}
-        {% set showReferencesContent = false %}
-      {% endif %}
+      <p class="govuk-body govuk-!-margin-bottom-2">Your application needs to include 2 references.</p>
+      <p class="govuk-body govuk-!-margin-bottom-2">It takes 8 days to get a reference on average. You can request as many references as you like to increase the chances of getting 2 quickly.</p>
+      <p class="govuk-body">Once you’ve received 2 or more references, you can select which 2 you want to include in your application.</p>
+      {% set referencesItemText = "Request your references" %}
+      {% set referencesTagText = incompleteTagText %}
+      {% set referencesTagClass = incompleteTagClass %}
+    {% endif %}
+
+    {% if references | length > 0 %}
+      <ul class="govuk-list">
+        {% for reference in references %}
+          <li class="govuk-body-s"><span class="app-status-indicator {{ reference.status | statusClass("app-status-indicator") }}"></span> <b>{{ reference.name }}</b>: {{ reference.status }}</li>
+        {% endfor %}
+      </ul>
     {% endif %}
 
     {{ appTaskList({
       items: [{
         text: referencesItemText,
         href: applicationPath + "/references",
+        id: "referees"
+      }, {
+        text: "Select 2 references",
+        href: "#" if readyReferences | length >= 2,
         id: "references",
         tag: {
-          classes: referencesTagClass,
-          text: referencesTagText
-        },
-        content: referencesContent | safe if showReferencesContent
+          text: "Completed"
+        } if readyReferences | length >= 2 else {
+          classes: incompleteTagClass,
+          text: "Cannot start yet"
+        }
       }]
     }) }}
   </section>
@@ -242,8 +242,8 @@
         href: applicationPath + "/work-history" + ("/review" if applicationValue("workHistoryDisclose")),
         id: "work-history",
         tag: {
-          classes: tagClassesForSection(applicationValue(["completed", "workHistory"])),
-          text: tagTextForSection(complted=applicationValue(["completed", "workHistory"]))
+          classes: tagClassesForSection(completed=applicationValue(["completed", "workHistory"])),
+          text: tagTextForSection(completed=applicationValue(["completed", "workHistory"]))
         }
       }, {
         text: "Unpaid experience",
@@ -251,7 +251,7 @@
         id: "unpaid-experience",
         tag: {
           classes: tagClassesForSection(completed=applicationValue(["completed", "unpaidExperience"])),
-          text: tagTextForSection(complted=applicationValue(["completed", "unpaidExperience"]))
+          text: tagTextForSection(completed=applicationValue(["completed", "unpaidExperience"]))
         }
       }]
     }) }}
@@ -288,7 +288,7 @@
         href: applicationPath + "/additional-support" + ("/review" if applicationValue("additionalSupportDisclose")),
         id: "additional-support",
         tag: {
-          classes: tagClassesForSection(applicationValue(["completed", "additionalSupport"])),
+          classes: tagClassesForSection(completed=applicationValue(["completed", "additionalSupport"])),
           text: tagTextForSection(completed=applicationValue(["completed", "additionalSupport"]))
         }
       }, {
@@ -312,7 +312,7 @@
         id: "safeguarding",
         tag: {
           classes: tagClassesForSection(completed=applicationValue(["completed", "safeguarding"])),
-          text: tagTextForSection(complted=applicationValue(["completed", "safeguarding"]))
+          text: tagTextForSection(completed=applicationValue(["completed", "safeguarding"]))
         }
       }]
     }) }}

--- a/app/views/application/references/relationship.njk
+++ b/app/views/application/references/relationship.njk
@@ -20,13 +20,13 @@
 
 {% block primary %}
   {% if referee.type == "Academic" %}
-    {% set relationshipExample = "He was my course supervisor at university. I’ve known him for a year" %}
+    {% set relationshipExample = "They were my course supervisor at university. I’ve known them for a year" %}
   {% elif referee.type == "Professional" %}
-    {% set relationshipExample = "He was my line manager in my last job. I’ve known him for 2 years" %}
+    {% set relationshipExample = "They were my line manager in my last job. I’ve known them for 2 years" %}
   {% elif referee.type == "School-based" %}
-    {% set relationshipExample = "She’s the deputy head at the school where I currently volunteer. I’ve known her for 3 years" %}
+    {% set relationshipExample = "They are the deputy head at the school where I currently volunteer. I’ve known them for 3 years" %}
   {% else %}
-    {% set relationshipExample = "She’s the head coach for my athletics club. I’ve known her for 5 years" %}
+    {% set relationshipExample = "They are the head coach for my athletics club. I’ve known them for 5 years" %}
   {% endif %}
 
   {{ govukCharacterCount({

--- a/app/views/application/references/review.njk
+++ b/app/views/application/references/review.njk
@@ -2,7 +2,7 @@
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set formaction = applicationPath %}
-{% set title = "References" %}
+{% set title = "Reference requests" %}
 {% set allowsFeedback = true %}
 {% set referrer = applicationPath + "/references/review" %}
 {% set references = applicationValue(["references"]) | toArray %}
@@ -26,26 +26,24 @@
 {% endblock %}
 
 {% block primary %}
-  {% if readyReferences | length < 2 %}
-  <div class="govuk-inset-text govuk-!-margin-top-0">
-    {% if references | length < 2 %}
-      <h2 class="govuk-heading-m">Add a second referee</h2>
-      <p class="govuk-body">You need 2 references before you can submit your application.</p>
-      {{ govukButton({
-        text: "Add a second referee",
-        href: "/application/" + applicationId + "/references/add?referrer=" + referrer
-      }) }}
-    {% else %}
-      <h2 class="govuk-heading-m">Add another referee</h2>
-      <p class="govuk-body">You can add more referees to increase the chances of getting 2 references quickly.</p>
-      <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
-      {{ govukButton({
-        text: "Add another referee",
-        href: "/application/" + applicationId + "/references/add?referrer=" + referrer
-      }) }}
-    {% endif %}
+  <div class="govuk-!-width-two-thirds">
+    <div class="govuk-inset-text govuk-!-margin-top-0">
+      {% if references | length < 2 %}
+        <p class="govuk-body">You need to get 2 references back before you can submit your application.</p>
+        {{ govukButton({
+          text: "Request a second reference",
+          href: "/application/" + applicationId + "/references/add?referrer=" + referrer
+        }) }}
+      {% else %}
+        <p class="govuk-body">You can request as many references as you like but you can only submit 2 with your application.</p>
+        {{ govukButton({
+          classes: "govuk-button--secondary",
+          text: "Request another reference",
+          href: "/application/" + applicationId + "/references/add?referrer=" + referrer
+        }) }}
+      {% endif %}
+    </div>
   </div>
-  {% endif %}
 
   {% if readyReferences.length %}
     <h2 class="govuk-heading-m">References that have been given</h2>

--- a/app/views/application/references/start.njk
+++ b/app/views/application/references/start.njk
@@ -1,6 +1,6 @@
 {% extends "_content.njk" %}
 
-{% set title = "Choose your referees" %}
+{% set title = "Requesting a reference" %}
 {% set allowsFeedback = true %}
 
 {% block pageNavigation %}
@@ -17,14 +17,20 @@
 {% endblock %}
 
 {% block primary %}
+  <h2 class="govuk-heading-m">Who to choose as a referee</h2>
   <p class="govuk-body">Referees should not be family members, partners or friends.</p>
-  <p class="govuk-body">Choose at least one academic referee if you graduated in the last 5 years or you do not have a grade for your degree yet.</p>
+  <p class="govuk-body">If you graduated in the last 5 years, or you do not yet have a grade for your degree, choose at least one academic referee.</p>
+  <p class="govuk-body">If you’re applying for a salaried course, one of your references must be from an employer.</p>
   <p class="govuk-body">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
-  <p class="govuk-body">If you’re applying for a School Direct (Salaried) course, one of your references must be from an employer.</p>
-  <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
-  <h2 class="govuk-heading-m">Contact your referees</h2>
-  <p class="govuk-body">Contact your referees in advance to check that they can submit a reference quickly online.</p>
-  <p class="govuk-body">Check that they can give you a full reference and not just confirm the dates you worked there. Providers need to know about your suitability for teaching.</p>
+
+  <h2 class="govuk-heading-m">Contact your referee</h2>
+  <p class="govuk-body">Your referee will receive a link to an online form to complete. References sent to providers by email will not be accepted.</p>
+  <p class="govuk-body">Contact your referee in advance to check that they can:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>type or paste their reference into an online form (with a 500-word limit)</li>
+    <li>submit a reference quickly, so as not to delay your application</li>
+    <li>give you a full reference – providers need to know if you’re suitable to become a teacher</li>
+  </ul>
   {{ govukButton({
     text: "Continue",
     href: "/application/" + applicationId + "/references/" + id + "/type/"


### PR DESCRIPTION
We’ve changed a bit of the content around references, as well as the status indicators. But we haven’t prototyped the new reference selection process.

This PR updates the application menu and other pages to bring them closer inline with what’s on (or soon will be on) prod, but without adding the select 2 references flow.

Is that a problem do we think? 