### PR TITLE
Add follow-up residency question

### DIFF
--- a/app/routes/application/personal-information.js
+++ b/app/routes/application/personal-information.js
@@ -27,6 +27,22 @@ module.exports = router => {
     }
   })
 
+  // Residency question answer branching
+  router.post('/application/:applicationId/personal-information/residency', (req, res) => {
+    const { referrer } = req.session.data
+    const { applicationId } = req.params
+    const application = req.session.data.applications[applicationId]
+    const { nationality } = application.candidate
+
+    const answer = application.candidate.residencyDisclose
+
+    if (answer === 'yes') {
+      res.redirect(`/application/${applicationId}/personal-information/review`)
+    } else {
+      res.redirect(`/application/${applicationId}/personal-information/residency-sponsorship`)
+    }
+  })
+
   // Render other personal information pages
   router.get('/application/:applicationId/personal-information/:view', (req, res) => {
     const { view } = req.params

--- a/app/views/_includes/review/personal-information.njk
+++ b/app/views/_includes/review/personal-information.njk
@@ -27,9 +27,21 @@
   }) if not completed and showIncomplete }}
 
   {% set residencyText %}
-    <p class="govuk-body">{{ applicationValue(["candidate", "residencyDisclose"]) }}</p>
-    {% if applicationValue(["candidate", "residency"]) and applicationValue(["candidate", "residencyDisclose"]) == "I have the right to work or study in the UK" %}
-      <p class="govuk-body">{{ applicationValue(["candidate", "residency"]) | nl2br }}</p>
+    <p class="govuk-body">
+      {% if applicationValue(["candidate", "residencyDisclose"]) == 'yes' %}
+        {{ applicationValue(["candidate", "residency"]) }}
+      {% else %}
+        Not yet
+      {% endif %}
+    </p>
+  {% endset %}
+
+  {% set residencyRouteText %}
+
+    {% if applicationValue(["candidate", "residencyRoute"]) == 'sponsorship' %}
+      <p class="govuk-body">A visa sponsored by a course provider</p>
+    {% else %}
+      <p class="govuk-body">{{ applicationValue(["candidate", "residencyRouteDetails"]) }}</p>
     {% endif %}
   {% endset %}
 
@@ -80,7 +92,7 @@
         } if canAmend
       }, {
         key: {
-          text: "Immigration status"
+          text: "Do you have the right to work or study in the UK?"
         },
         value: {
           html: residencyText
@@ -92,7 +104,23 @@
             visuallyHiddenText: "immigration status"
           }]
         } if canAmend
-      } if applicationValue(["candidate", "residencyDisclose"])]
+      } if applicationValue(["candidate", "residencyDisclose"]),
+      {
+        key: {
+          text: "How will you gain the right to work or study in the UK?"
+        },
+        value: {
+          html: residencyRouteText
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/personal-information/residency-sponsorship?referrer=" + referrer,
+            text: "Change",
+            visuallyHiddenText: "how you will gain the right to work or study in the UK"
+          }]
+        } if canAmend
+      } if applicationValue(["candidate", "residencyRoute"])
+      ]
     })
   }) }}
 {% endif %}

--- a/app/views/application/personal-information/residency-sponsorship.njk
+++ b/app/views/application/personal-information/residency-sponsorship.njk
@@ -1,0 +1,59 @@
+{% extends "_layout.njk" %}
+
+{% set formaction = "/application/" + applicationId + "/personal-information/review" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: (referrer if referrer else "/application/" + applicationId + "/personal-information/residency")
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <form{% if formaction %} action="{{ formaction }}"{% endif %} method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        {% set otherRouteHtml %}
+          {{ govukCharacterCount({
+            label: {
+              text: "Give details"
+            },
+            maxwords: 200,
+            rows: 5
+          } | decorateApplicationAttributes(["candidate", "residencyRouteDetails"])) }}
+        {% endset -%}
+
+        {{ govukRadios({
+          fieldset: {
+            legend: {
+              text: "How will you gain the right to work or study in the UK?",
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            attributes: {
+              "data-module": "clear-hidden"
+            }
+          },
+          items: [{
+            value: "sponsorship",
+            text: "A visa sponsored by a course provider"
+          }, {
+            value: "other",
+            text: "Another route",
+            hint: {
+              text: "For example, if you are applying for a Family visa or a Graduate visa"
+            },
+            conditional: {
+              html: otherRouteHtml
+            }
+          }]
+        } | decorateApplicationAttributes(["candidate", "residencyRoute"])) }}
+
+        {{ govukButton({
+          text: "Save and continue"
+        }) }}
+      </div>
+    </div>
+  </form>
+{% endblock %}

--- a/app/views/application/personal-information/residency.njk
+++ b/app/views/application/personal-information/residency.njk
@@ -1,6 +1,6 @@
 {% extends "_layout.njk" %}
 
-{% set formaction = referrer or "/application/" + applicationId + "/personal-information/review" %}
+{% set formaction = "/application/" + applicationId + "/personal-information/residency" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -42,13 +42,13 @@
             html: "To get help with student visas and your immigration status, speak to a <a href=\"https://beta-adviser-getintoteaching.education.gov.uk/\">teacher training adviser</a>."
           },
           items: [{
-            value: "I have the right to work or study in the UK",
+            value: "yes",
             text: "Yes",
             conditional: {
               html: rightToWorkStudy
             }
           }, {
-            value: "I will need to apply for permission to work or study in the UK",
+            value: "no",
             text: "Not yet, or not sure"
           }]
         } | decorateApplicationAttributes(["candidate", "residencyDisclose"])) }}


### PR DESCRIPTION
This adds a new question if someone indicates that they do not yet have the right to work or study in the UK.

The question asks them how they will gain the right to work or study in the UK, with 2 possible answers:

* A visa sponsored by a course provider
* Another route

(If they select the second one, they are asked to give details).

The need for this question is so that:

1) if they are planning to get a visa sponsored by a provider, we can warn them and give guidance if they apply for a course by a provider who cannot offer this.

2) if they are gaining the right to work or study in the UK in some other way, the details they give may help providers to understand the context of the candidate’s immigration status, which may avoid them rejecting the candidate on the ground that they cannot sponsor a visa.

## Screenshots

### Follow-up question

<img width="756" alt="Screenshot 2021-07-28 at 17 08 24" src="https://user-images.githubusercontent.com/30665/127358412-49749d96-4746-4d20-81ea-2cf27358caa1.png">

<img width="785" alt="Screenshot 2021-07-28 at 17 08 52" src="https://user-images.githubusercontent.com/30665/127358442-6f5cb9c8-4fa1-4f5d-b6df-189158483749.png">

### Review page summary

The way that the preceding question has been summarised has been tweaked too, to more directly match the question asked, and to include the free text answer given if they do have the right to work or study in the UK.

<img width="1033" alt="Screenshot 2021-07-28 at 17 09 18" src="https://user-images.githubusercontent.com/30665/127358484-4a7e8c3e-6156-4691-a6f2-17343119d9d3.png">
