### PR TITLE
Remove "not sure" from label on "Right to work or study in the UK" question

### DIFF
--- a/app/views/application/personal-information/residency.njk
+++ b/app/views/application/personal-information/residency.njk
@@ -49,7 +49,7 @@
             }
           }, {
             value: "no",
-            text: "Not yet, or not sure"
+            text: "Not yet"
           }]
         } | decorateApplicationAttributes(["candidate", "residencyDisclose"])) }}
 


### PR DESCRIPTION
This changes "Not yet, or not sure" to just "Not yet".

This is because:

* If someone selects this answer, we show a follow-up question asking how they will get the right to work or study. This doesn't make sense if they're not sure.
* We should help a candidate to answer the question instead, or signpost them to a teacher training adviser
* If we are not sure of their right to work or study, we can't offer relevant guidance when applying for courses which may or may not sponsor visas.

If removing this proves to be a big blocker for some candidates, we could consider adding "Not sure" back as a third option instead.