### PR TITLE
Tweak to GCSE question page

### DIFF
--- a/app/views/application/gcse/index.njk
+++ b/app/views/application/gcse/index.njk
@@ -66,6 +66,9 @@
               "data-module": "clear-hidden"
             }
           },
+          hint: {
+            text: "This should be different from an English as a foreign language qualification."
+          } if subject == "English",
           items: [{
             text: "GCSE"
           }, {
@@ -85,7 +88,7 @@
           }, {
             divider: "or"
           }, {
-            text: "I don’t have " + ("an " + subject if subject == 'English' else 'a ' + subject) + " qualification yet",
+            text: "I do not have a GCSE in " + subject + " (or equivalent) yet",
             value: "not-yet"
           }]
         } | decorateApplicationAttributes(["gcse", id, "type"])) }}


### PR DESCRIPTION
This is to try and avoid ambiguity in "English" qualifications, which could be "English as a subject" (eg as taught in the UK) vs "English as a foreign language" (as may be taught in non-English speaking countries).

### Screenshot

<img width="772" alt="Screenshot 2021-08-16 at 13 27 34" src="https://user-images.githubusercontent.com/30665/129563712-c659771d-f995-4421-9a09-5bd9661a3ab0.png">
