### PR TITLE
Drop text advising candidates speak to teacher training advisers about immigration

### DIFF
--- a/app/views/application/personal-information/immigration.njk
+++ b/app/views/application/personal-information/immigration.njk
@@ -11,9 +11,6 @@
 
 {% block primary %}
   {{ govukRadios({
-    hint: {
-      html: "To get help with student visas and your immigration status, speak to a <a href=\"https://beta-adviser-getintoteaching.education.gov.uk/\">teacher training adviser</a>."
-    },
     items: [{
       value: "Yes",
       text: "Yes"


### PR DESCRIPTION
Teacher training advisers cannot usually help with this, as all they do is point candidates towards the Home Office.