### PR TITLE
Add ability to provide both contact and permanent addresses

### DIFF
--- a/app/data/application-international.js
+++ b/app/data/application-international.js
@@ -129,13 +129,14 @@ module.exports = {
   },
   contactInformation: {
     tel: '07944 386555',
-    addressType: 'domestic',
+    addressFormat: 'domestic',
     address: {
       line1: '5 Royal Exchange Square',
       level2: 'Glasgow',
       country: 'United Kingdom',
       postalCode: 'G1 3AH'
-    }
+    },
+    permanentAddressType: 'contact'
   },
   additionalSupportDisclose: 'Yes',
   additionalSupport: 'I currently require the use of a wheelchair.',

--- a/app/data/application.js
+++ b/app/data/application.js
@@ -129,7 +129,7 @@ module.exports = {
   },
   contactInformation: {
     tel: '07944 386555',
-    addressType: 'domestic',
+    addressFormat: 'domestic',
     address: {
       line1: '5 Claremont Road',
       line2: '',
@@ -137,7 +137,8 @@ module.exports = {
       level1: 'West Yorkshire',
       country: 'United Kingdom',
       postalCode: 'LS28 7DQ'
-    }
+    },
+    permanentAddressType: 'contact'
   },
   additionalSupportDisclose: 'No',
   safeguardingDisclose: 'No',

--- a/app/filters.js
+++ b/app/filters.js
@@ -193,8 +193,10 @@ module.exports = (env) => {
     if (obj) {
       const arr = []
       for (const [key, value] of Object.entries(obj)) {
-        value.id = key
-        arr.push(value)
+        if (value) {
+          value.id = key
+          arr.push(value)
+        }
       }
       return arr
     } else {

--- a/app/routes/application/contact-information.js
+++ b/app/routes/application/contact-information.js
@@ -2,16 +2,16 @@ const utils = require('../../utils')
 
 module.exports = router => {
   // Render other contact pages
-  router.get('/application/:applicationId/contact-information/where-do-you-live', (req, res) => {
+  router.get('/application/:applicationId/contact-information/contact-address', (req, res) => {
     const { referrer } = req.query
 
-    res.render('application/contact-information/where-do-you-live', {
+    res.render('application/contact-information/contact-address', {
       referrer
     })
   })
 
   // Contact address type answer branching
-  router.all('/application/:applicationId/contact-information/where-do-you-live/answer', (req, res) => {
+  router.all('/application/:applicationId/contact-information/contact-address/answer', (req, res) => {
     const { applicationId } = req.params
     const application = utils.applicationData(req)
     const { addressType } = application.contactInformation
@@ -21,20 +21,20 @@ module.exports = router => {
       if (addressLookup) {
         res.redirect(`/application/${applicationId}/contact-information/lookup-address`)
       } else {
-        res.redirect(`/application/${applicationId}/contact-information/uk-address`)
+        res.redirect(`/application/${applicationId}/contact-information/uk-contact-address`)
       }
     } else {
-      res.redirect(`/application/${applicationId}/contact-information/international-address`)
+      res.redirect(`/application/${applicationId}/contact-information/international-contact-address`)
     }
   })
 
   // Second address type answer branching
-  router.all('/application/:applicationId/contact-information/second-address/answer', (req, res) => {
+  router.all('/application/:applicationId/contact-information/permanent-address/answer', (req, res) => {
     const { applicationId } = req.params
     const application = utils.applicationData(req)
-    const { secondAddress } = application.contactInformation
+    const { permanentAddressType } = application.contactInformation
 
-    if (secondAddress === 'contactAddess') {
+    if (permanentAddressType === 'contact') {
       res.redirect(`/application/${applicationId}/contact-information/review`)
     } else {
       res.redirect(`/application/${applicationId}/contact-information/where-is-your-permanent-address`)
@@ -55,7 +55,7 @@ module.exports = router => {
   })
 
   // Render address page
-  router.get('/application/:applicationId/contact-information/:view(uk-address|international-address)', (req, res) => {
+  router.get('/application/:applicationId/contact-information/:view(uk-contact-address|international-contact-address)', (req, res) => {
     const { referrer } = req.query
     const { view } = req.params
 

--- a/app/routes/application/contact-information.js
+++ b/app/routes/application/contact-information.js
@@ -10,14 +10,14 @@ module.exports = router => {
     })
   })
 
-  // Address type answer branching
+  // Contact address type answer branching
   router.all('/application/:applicationId/contact-information/where-do-you-live/answer', (req, res) => {
     const { applicationId } = req.params
     const application = utils.applicationData(req)
-    const location = application.contactInformation.addressType
+    const { addressType } = application.contactInformation
     const { addressLookup } = req.session.data.flags
 
-    if (location === 'domestic') {
+    if (addressType === 'domestic') {
       if (addressLookup) {
         res.redirect(`/application/${applicationId}/contact-information/lookup-address`)
       } else {
@@ -25,6 +25,32 @@ module.exports = router => {
       }
     } else {
       res.redirect(`/application/${applicationId}/contact-information/international-address`)
+    }
+  })
+
+  // Second address type answer branching
+  router.all('/application/:applicationId/contact-information/second-address/answer', (req, res) => {
+    const { applicationId } = req.params
+    const application = utils.applicationData(req)
+    const { secondAddress } = application.contactInformation
+
+    if (secondAddress === 'contactAddess') {
+      res.redirect(`/application/${applicationId}/contact-information/review`)
+    } else {
+      res.redirect(`/application/${applicationId}/contact-information/where-is-your-permanent-address`)
+    }
+  })
+
+  // Permanent address type answer branching
+  router.all('/application/:applicationId/contact-information/where-is-your-permanent-address/answer', (req, res) => {
+    const { applicationId } = req.params
+    const application = utils.applicationData(req)
+    const { permanentAddressType } = application.contactInformation
+
+    if (permanentAddressType === 'domestic') {
+      res.redirect(`/application/${applicationId}/contact-information/uk-permanent-address`)
+    } else {
+      res.redirect(`/application/${applicationId}/contact-information/international-permanent-address`)
     }
   })
 

--- a/app/routes/application/contact-information.js
+++ b/app/routes/application/contact-information.js
@@ -14,10 +14,10 @@ module.exports = router => {
   router.all('/application/:applicationId/contact-information/contact-address/answer', (req, res) => {
     const { applicationId } = req.params
     const application = utils.applicationData(req)
-    const { addressType } = application.contactInformation
+    const { addressFormat } = application.contactInformation
     const { addressLookup } = req.session.data.flags
 
-    if (addressType === 'domestic') {
+    if (addressFormat === 'domestic') {
       if (addressLookup) {
         res.redirect(`/application/${applicationId}/contact-information/lookup-address`)
       } else {
@@ -45,9 +45,9 @@ module.exports = router => {
   router.all('/application/:applicationId/contact-information/where-is-your-permanent-address/answer', (req, res) => {
     const { applicationId } = req.params
     const application = utils.applicationData(req)
-    const { permanentAddressType } = application.contactInformation
+    const { permanentAddressFormat } = application.contactInformation
 
-    if (permanentAddressType === 'domestic') {
+    if (permanentAddressFormat === 'domestic') {
       res.redirect(`/application/${applicationId}/contact-information/uk-permanent-address`)
     } else {
       res.redirect(`/application/${applicationId}/contact-information/international-permanent-address`)

--- a/app/views/_form.njk
+++ b/app/views/_form.njk
@@ -18,7 +18,8 @@
             },
             attributes: {
               "data-module": "clear-hidden"
-            }
+            },
+            describedBy: describedBy if describedBy
           }) %}
             {% block primary %}{% endblock %}
           {% endcall %}

--- a/app/views/_includes/review/contact-information.njk
+++ b/app/views/_includes/review/contact-information.njk
@@ -2,7 +2,7 @@
 {% set entered = applicationValue(["contactInformation", "tel"]) %}
 
 {% set permanentAddressHtml %}
-  {% if applicationValue(["contactInformation", "secondAddress"]) == "contactAddess" %}
+  {% if applicationValue(["contactInformation", "permanentAddressType"]) == "contact" %}
     Same as contact address
   {% else %}
     {{ applicationValue(["contactInformation", "permanentAddress"]) | formatAddress | nl2br | safe or "Not entered" }}
@@ -74,7 +74,7 @@
         },
         actions: {
           items: [{
-            href: applicationPath + "/contact-information/where-do-you-live?referrer=" + referrer,
+            href: applicationPath + "/contact-information/contact-address?referrer=" + referrer,
             text: "Change",
             visuallyHiddenText: "address"
           }]
@@ -88,7 +88,7 @@
         },
         actions: {
           items: [{
-            href: applicationPath + "/contact-information/second-address?referrer=" + referrer,
+            href: applicationPath + "/contact-information/permanent-address?referrer=" + referrer,
             text: "Change",
             visuallyHiddenText: "permanent address"
           }]

--- a/app/views/_includes/review/contact-information.njk
+++ b/app/views/_includes/review/contact-information.njk
@@ -1,6 +1,14 @@
 {% set completed = applicationValue(["completed", "contactInformation"]) %}
 {% set entered = applicationValue(["contactInformation", "tel"]) %}
 
+{% set permanentAddressHtml %}
+  {% if applicationValue(["contactInformation", "secondAddress"]) == "contactAddess" %}
+    Same as contact address
+  {% else %}
+    {{ applicationValue(["contactInformation", "permanentAddress"]) | formatAddress | nl2br | safe or "Not entered" }}
+  {% endif %}
+{% endset %}
+
 {% if not entered %}
   {{ appSuggestion({
     id: "contactInformation",
@@ -59,7 +67,7 @@
         } if canAmend
       } if data.flags.selfAmendEmailAddress, {
         key: {
-          text: "Address"
+          text: "Contact address"
         },
         value: {
           html: applicationValue(["contactInformation", "address"]) | formatAddress | nl2br | safe or "Not entered"
@@ -73,19 +81,19 @@
         } if canAmend
       }, {
         key: {
-          text: "Contact address"
+          text: "Permanent address"
         },
         value: {
-          html: applicationValue(["contactInformation", "contactAddress"]) | formatAddress | nl2br | safe or "Not entered"
+          html: permanentAddressHtml
         },
         actions: {
           items: [{
-            href: applicationPath + "/contact-information/contact-address?referrer=" + referrer,
+            href: applicationPath + "/contact-information/second-address?referrer=" + referrer,
             text: "Change",
-            visuallyHiddenText: "contact address"
+            visuallyHiddenText: "permanent address"
           }]
         } if canAmend
-      } if applicationValue(["contactInformation", "contactAddress"]) and applicationValue(["contactInformation", "address", "country"]) and applicationValue(["contactInformation", "contactAddressIsResidence"]) == "A different address"]
+      }]
     })
   }) }}
 {% endif %}

--- a/app/views/application/contact-information/contact-address.njk
+++ b/app/views/application/contact-information/contact-address.njk
@@ -34,7 +34,7 @@
         html: internationalCountryHtml
       }
     }]
-  } | decorateApplicationAttributes(["contactInformation", "addressType"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "addressFormat"])) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/contact-information/contact-address.njk
+++ b/app/views/application/contact-information/contact-address.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "What is your contact address?" %}
+{% set title = "Where is your contact address?" %}
 {% set formaction = "/application/" + applicationId + "/contact-information/contact-address/answer" %}
 
 {% block pageNavigation %}

--- a/app/views/application/contact-information/contact-address.njk
+++ b/app/views/application/contact-information/contact-address.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "Where is your contact address?" %}
+{% set title = "Where do you live currently?" %}
 {% set formaction = "/application/" + applicationId + "/contact-information/contact-address/answer" %}
 
 {% block pageNavigation %}
@@ -21,9 +21,6 @@
   {% endset %}
 
   {{ govukRadios({
-    hint: {
-      text: "Providers may send post to this address about your course or interviews."
-    },
     items: [{
       text: "In the UK",
       value: "domestic"

--- a/app/views/application/contact-information/contact-address.njk
+++ b/app/views/application/contact-information/contact-address.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
-{% set title = "Where do you currently live?" %}
-{% set formaction = "/application/" + applicationId + "/contact-information/where-do-you-live/answer" %}
+{% set title = "What is your contact address?" %}
+{% set formaction = "/application/" + applicationId + "/contact-information/contact-address/answer" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -21,6 +21,9 @@
   {% endset %}
 
   {{ govukRadios({
+    hint: {
+      text: "Providers may send post to this address about your course or interviews."
+    },
     items: [{
       text: "In the UK",
       value: "domestic"

--- a/app/views/application/contact-information/index.njk
+++ b/app/views/application/contact-information/index.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set title = "Contact information" %}
-{% set formaction = referrer or "/application/" + applicationId + "/contact-information/where-do-you-live" %}
+{% set formaction = referrer or "/application/" + applicationId + "/contact-information/contact-address" %}
 
 {% block pageNavigation %}
   {% if referrer %}

--- a/app/views/application/contact-information/international-contact-address.njk
+++ b/app/views/application/contact-information/international-contact-address.njk
@@ -55,7 +55,7 @@
 
   {# Explictly mark this as an international address if came to this page via a link rather than by form submission on ‘Where do you live’ page #}
   {{ govukInput({
-    name: "applications[" + applicationId + "][contactInformation][addressType]",
+    name: "applications[" + applicationId + "][contactInformation][addressFormat]",
     type: "hidden",
     value: "international"
   }) }}

--- a/app/views/application/contact-information/international-contact-address.njk
+++ b/app/views/application/contact-information/international-contact-address.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "What is your address?" %}
+{% set title = "What is your contact address?" %}
 
 {% if not referrer and not applicationValue(["contactInformation", "permanentAddressType"]) %}
   {% set formaction = "/application/" + applicationId + "/contact-information/permanent-address" %}

--- a/app/views/application/contact-information/international-contact-address.njk
+++ b/app/views/application/contact-information/international-contact-address.njk
@@ -2,15 +2,15 @@
 
 {% set title = "What is your address?" %}
 
-{% if not referrer and not applicationValue(["contactInformation", "secondAddress"]) %}
-  {% set formaction = "/application/" + applicationId + "/contact-information/second-address" %}
+{% if not referrer and not applicationValue(["contactInformation", "permanentAddressType"]) %}
+  {% set formaction = "/application/" + applicationId + "/contact-information/permanent-address" %}
 {% else %}
   {% set formaction = "/application/" + applicationId + "/contact-information/review" %}
 {% endif %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: referrer if referrer else "/application/" + applicationId + "/contact-information/where-do-you-live"
+    href: referrer if referrer else "/application/" + applicationId + "/contact-information/contact-address"
   }) }}
 {% endblock %}
 
@@ -31,7 +31,7 @@
 
   {{ govukInput({
     label: {
-      text: "Town or city"
+      html: "City, town or village"
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "address-level2"
@@ -39,7 +39,7 @@
 
   {{ govukInput({
     label: {
-      text: "County"
+      html: "Region, state or province"
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "address-level1"
@@ -47,11 +47,18 @@
 
   {{ govukInput({
     label: {
-      text: "Postal code"
+      text: "ZIP or postal code"
     },
-    classes: "govuk-input--width-10",
+    classes: "govuk-!-width-two-thirds",
     autocomplete: "postal-code"
   } | decorateApplicationAttributes(["contactInformation", "address", "postalCode"])) }}
+
+  {# Explictly mark this as an international address if came to this page via a link rather than by form submission on ‘Where do you live’ page #}
+  {{ govukInput({
+    name: "applications[" + applicationId + "][contactInformation][addressType]",
+    type: "hidden",
+    value: "international"
+  }) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/contact-information/international-contact-address.njk
+++ b/app/views/application/contact-information/international-contact-address.njk
@@ -15,6 +15,8 @@
 {% endblock %}
 
 {% block primary %}
+  <p class="govuk-body">Providers may send post to this address about your course or interviews.</p>
+
   {{ govukInput({
     label: {
       html: "Building and street <span class=\"govuk-visually-hidden\">line 1 of 2</span>"

--- a/app/views/application/contact-information/international-permanent-address.njk
+++ b/app/views/application/contact-information/international-permanent-address.njk
@@ -1,12 +1,7 @@
 {% extends "_form.njk" %}
 
-{% set title = "What is your address?" %}
-
-{% if not referrer and not applicationValue(["contactInformation", "secondAddress"]) %}
-  {% set formaction = "/application/" + applicationId + "/contact-information/second-address" %}
-{% else %}
-  {% set formaction = "/application/" + applicationId + "/contact-information/review" %}
-{% endif %}
+{% set title = "What is your permanent address?" %}
+{% set formaction = "/application/" + applicationId + "/contact-information/review" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -20,14 +15,14 @@
       html: "Building and street <span class=\"govuk-visually-hidden\">line 1 of 2</span>"
     },
     autocomplete: "address-line1"
-  } | decorateApplicationAttributes(["contactInformation", "address", "line1"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "line1"])) }}
 
   {{ govukInput({
     label: {
       html: "<span class=\"govuk-visually-hidden\">Building and street line 2 of 2</span>"
     },
     autocomplete: "address-line2"
-  } | decorateApplicationAttributes(["contactInformation", "address", "line2"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "line2"])) }}
 
   {{ govukInput({
     label: {
@@ -35,7 +30,7 @@
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "address-level2"
-  } | decorateApplicationAttributes(["contactInformation", "address", "level2"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "level2"])) }}
 
   {{ govukInput({
     label: {
@@ -43,7 +38,7 @@
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "address-level1"
-  } | decorateApplicationAttributes(["contactInformation", "address", "level1"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "level1"])) }}
 
   {{ govukInput({
     label: {
@@ -51,11 +46,11 @@
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "postal-code"
-  } | decorateApplicationAttributes(["contactInformation", "address", "postalCode"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "postalCode"])) }}
 
-  {# Explictly mark this as an international address if came to this page via a link rather than by form submission on ‘Where do you live’ page #}
+  {# Explictly mark this as an international address if came to this page via a link rather than by form submission on ‘Where is your permanent address?’ page #}
   {{ govukInput({
-    name: "applications[" + applicationId + "][contactInformation][addressType]",
+    name: "applications[" + applicationId + "][contactInformation][permanentAddressType]",
     type: "hidden",
     value: "international"
   }) }}

--- a/app/views/application/contact-information/international-permanent-address.njk
+++ b/app/views/application/contact-information/international-permanent-address.njk
@@ -5,7 +5,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: referrer if referrer else "/application/" + applicationId + "/contact-information/where-do-you-live"
+    href: referrer if referrer else "/application/" + applicationId + "/contact-information/contact-address"
   }) }}
 {% endblock %}
 

--- a/app/views/application/contact-information/international-permanent-address.njk
+++ b/app/views/application/contact-information/international-permanent-address.njk
@@ -50,7 +50,7 @@
 
   {# Explictly mark this as an international address if came to this page via a link rather than by form submission on ‘Where is your permanent address?’ page #}
   {{ govukInput({
-    name: "applications[" + applicationId + "][contactInformation][permanentAddressType]",
+    name: "applications[" + applicationId + "][contactInformation][permanentAddressFormat]",
     type: "hidden",
     value: "international"
   }) }}

--- a/app/views/application/contact-information/lookup-address.njk
+++ b/app/views/application/contact-information/lookup-address.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "What is your address?" %}
+{% set title = "What is your contact address?" %}
 {% set formaction = "/application/" + applicationId + "/contact-information/select-address" %}
 
 {% block pageNavigation %}

--- a/app/views/application/contact-information/lookup-address.njk
+++ b/app/views/application/contact-information/lookup-address.njk
@@ -5,7 +5,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: "/application/" + applicationId + "/contact-information/where-do-you-live"
+    href: "/application/" + applicationId + "/contact-information/contact-address"
   }) }}
 {% endblock %}
 
@@ -26,6 +26,6 @@
   }) }}
 
   <p class="govuk-body">
-    <a href="/application/{{ applicationId }}/contact-information/international-address">I live outside the UK</a>
+    <a href="/application/{{ applicationId }}/contact-information/international-contact-address">I live outside the UK</a>
   </p>
 {% endblock %}

--- a/app/views/application/contact-information/permanent-address.njk
+++ b/app/views/application/contact-information/permanent-address.njk
@@ -2,7 +2,7 @@
 
 {% set title = "What is your permanent address?" %}
 
-{% set formaction = "/application/" + applicationId + "/contact-information/second-address/answer" %}
+{% set formaction = "/application/" + applicationId + "/contact-information/permanent-address/answer" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -17,15 +17,15 @@
     },
     items: [{
       text: "Same as contact address",
-      value: "contactAddess",
+      value: "contact",
       hint: {
         text: applicationValue(["contactInformation", "address"]) | formatAddress(", ")
       }
     }, {
       text: "A different address",
-      value: "permanentAddess"
+      value: "permanent"
     }]
-  } | decorateApplicationAttributes(["contactInformation", "secondAddress"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddressType"])) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/contact-information/second-address.njk
+++ b/app/views/application/contact-information/second-address.njk
@@ -1,0 +1,33 @@
+{% extends "_form.njk" %}
+
+{% set title = "What is your permanent address?" %}
+
+{% set formaction = "/application/" + applicationId + "/contact-information/second-address/answer" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: (referrer if referrer else "/application/" + applicationId + "/contact-information/")
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  {{ govukRadios({
+    hint: {
+      text: "This is the address where you normally live. It may be different from your contact address."
+    },
+    items: [{
+      text: "Same as contact address",
+      value: "contactAddess",
+      hint: {
+        text: applicationValue(["contactInformation", "address"]) | formatAddress(", ")
+      }
+    }, {
+      text: "A different address",
+      value: "permanentAddess"
+    }]
+  } | decorateApplicationAttributes(["contactInformation", "secondAddress"])) }}
+
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+{% endblock %}

--- a/app/views/application/contact-information/select-address.njk
+++ b/app/views/application/contact-information/select-address.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
-{% set title = "What is your address?" %}
+{% set title = "What is your contact address?" %}
 {% set formaction = "/application/" + applicationId + "/contact-information/review" %}
 
 {% block pageNavigation %}

--- a/app/views/application/contact-information/select-address.njk
+++ b/app/views/application/contact-information/select-address.njk
@@ -81,7 +81,7 @@
     }]
   } | decorateApplicationAttributes(["contactInformation", "address", "line1"])) }}
 
-  <p class="govuk-body"><a href="{{ applicationPath }}/contact-information/uk-address">I can’t find my address in the list</a></p>
+  <p class="govuk-body"><a href="{{ applicationPath }}/contact-information/uk-contact-address">I can’t find my address in the list</a></p>
 
   {{ govukInput({
     name: "applications[" + applicationId + "][contactInformation][address][line2]",

--- a/app/views/application/contact-information/uk-contact-address.njk
+++ b/app/views/application/contact-information/uk-contact-address.njk
@@ -2,15 +2,15 @@
 
 {% set title = "What is your address?" %}
 
-{% if not referrer and not applicationValue(["contactInformation", "secondAddress"]) %}
-  {% set formaction = "/application/" + applicationId + "/contact-information/second-address" %}
+{% if not referrer and not applicationValue(["contactInformation", "permanentAddressType"]) %}
+  {% set formaction = "/application/" + applicationId + "/contact-information/permanent-address" %}
 {% else %}
   {% set formaction = "/application/" + applicationId + "/contact-information/review" %}
 {% endif %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: referrer if referrer else "/application/" + applicationId + "/contact-information/where-do-you-live"
+    href: referrer if referrer else "/application/" + applicationId + "/contact-information/contact-address"
   }) }}
 {% endblock %}
 
@@ -31,7 +31,7 @@
 
   {{ govukInput({
     label: {
-      html: "City, town or village"
+      text: "Town or city"
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "address-level2"
@@ -39,7 +39,7 @@
 
   {{ govukInput({
     label: {
-      html: "Region, state or province"
+      text: "County"
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "address-level1"
@@ -47,18 +47,11 @@
 
   {{ govukInput({
     label: {
-      text: "ZIP or postal code"
+      text: "Postal code"
     },
-    classes: "govuk-!-width-two-thirds",
+    classes: "govuk-input--width-10",
     autocomplete: "postal-code"
   } | decorateApplicationAttributes(["contactInformation", "address", "postalCode"])) }}
-
-  {# Explictly mark this as an international address if came to this page via a link rather than by form submission on ‘Where do you live’ page #}
-  {{ govukInput({
-    name: "applications[" + applicationId + "][contactInformation][addressType]",
-    type: "hidden",
-    value: "international"
-  }) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/contact-information/uk-contact-address.njk
+++ b/app/views/application/contact-information/uk-contact-address.njk
@@ -1,3 +1,7 @@
+{% from "govuk/components/hint/macro.njk" import govukHint %}
+
+{% set describedBy = "address-hint" %}
+
 {% extends "_form.njk" %}
 
 {% set title = "What is your contact address?" %}
@@ -15,7 +19,9 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Providers may send post to this address about your course or interviews.</p>
+
+
+  {{ govukHint({id: describedBy, text: "Providers may send post to this address about your course or interviews." })}}
 
   {{ govukInput({
     label: {

--- a/app/views/application/contact-information/uk-contact-address.njk
+++ b/app/views/application/contact-information/uk-contact-address.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "What is your address?" %}
+{% set title = "What is your contact address?" %}
 
 {% if not referrer and not applicationValue(["contactInformation", "permanentAddressType"]) %}
   {% set formaction = "/application/" + applicationId + "/contact-information/permanent-address" %}

--- a/app/views/application/contact-information/uk-contact-address.njk
+++ b/app/views/application/contact-information/uk-contact-address.njk
@@ -15,6 +15,8 @@
 {% endblock %}
 
 {% block primary %}
+  <p class="govuk-body">Providers may send post to this address about your course or interviews.</p>
+
   {{ govukInput({
     label: {
       html: "Building and street <span class=\"govuk-visually-hidden\">line 1 of 2</span>"

--- a/app/views/application/contact-information/uk-permanent-address.njk
+++ b/app/views/application/contact-information/uk-permanent-address.njk
@@ -1,12 +1,7 @@
 {% extends "_form.njk" %}
 
-{% set title = "What is your address?" %}
-
-{% if not referrer and not applicationValue(["contactInformation", "secondAddress"]) %}
-  {% set formaction = "/application/" + applicationId + "/contact-information/second-address" %}
-{% else %}
-  {% set formaction = "/application/" + applicationId + "/contact-information/review" %}
-{% endif %}
+{% set title = "What is your permanent address?" %}
+{% set formaction = "/application/" + applicationId + "/contact-information/review" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -20,14 +15,14 @@
       html: "Building and street <span class=\"govuk-visually-hidden\">line 1 of 2</span>"
     },
     autocomplete: "address-line1"
-  } | decorateApplicationAttributes(["contactInformation", "address", "line1"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "line1"])) }}
 
   {{ govukInput({
     label: {
       html: "<span class=\"govuk-visually-hidden\">Building and street line 2 of 2</span>"
     },
     autocomplete: "address-line2"
-  } | decorateApplicationAttributes(["contactInformation", "address", "line2"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "line2"])) }}
 
   {{ govukInput({
     label: {
@@ -35,7 +30,7 @@
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "address-level2"
-  } | decorateApplicationAttributes(["contactInformation", "address", "level2"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "level2"])) }}
 
   {{ govukInput({
     label: {
@@ -43,7 +38,7 @@
     },
     classes: "govuk-!-width-two-thirds",
     autocomplete: "address-level1"
-  } | decorateApplicationAttributes(["contactInformation", "address", "level1"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "level1"])) }}
 
   {{ govukInput({
     label: {
@@ -51,7 +46,7 @@
     },
     classes: "govuk-input--width-10",
     autocomplete: "postal-code"
-  } | decorateApplicationAttributes(["contactInformation", "address", "postalCode"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "postalCode"])) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/contact-information/uk-permanent-address.njk
+++ b/app/views/application/contact-information/uk-permanent-address.njk
@@ -5,7 +5,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: referrer if referrer else "/application/" + applicationId + "/contact-information/where-do-you-live"
+    href: referrer if referrer else "/application/" + applicationId + "/contact-information/contact-address"
   }) }}
 {% endblock %}
 

--- a/app/views/application/contact-information/where-is-your-permanent-address.njk
+++ b/app/views/application/contact-information/where-is-your-permanent-address.njk
@@ -31,7 +31,7 @@
         html: internationalCountryHtml
       }
     }]
-  } | decorateApplicationAttributes(["contactInformation", "permanentAddressType"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddressFormat"])) }}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/contact-information/where-is-your-permanent-address.njk
+++ b/app/views/application/contact-information/where-is-your-permanent-address.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
-{% set title = "Where do you currently live?" %}
-{% set formaction = "/application/" + applicationId + "/contact-information/where-do-you-live/answer" %}
+{% set title = "Where is your permanent address?" %}
+{% set formaction = "/application/" + applicationId + "/contact-information/where-is-your-permanent-address/answer" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -17,7 +17,7 @@
         classes: "govuk-label--m"
       },
       items: countries
-    } | decorateApplicationAttributes(["contactInformation", "address", "country"])) }}
+    } | decorateApplicationAttributes(["contactInformation", "permanentAddress", "country"])) }}
   {% endset %}
 
   {{ govukRadios({
@@ -31,7 +31,7 @@
         html: internationalCountryHtml
       }
     }]
-  } | decorateApplicationAttributes(["contactInformation", "addressType"])) }}
+  } | decorateApplicationAttributes(["contactInformation", "permanentAddressType"])) }}
 
   {{ govukButton({
     text: "Save and continue"
@@ -42,8 +42,8 @@
   <script src="/public/javascripts/autocomplete.min.js"></script>
   <script>
     accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.querySelector('#contactInformation-address-country'),
-      defaultValue: '{{ applicationValue(["contactInformation", "address", "country"]) }}'
+      selectElement: document.querySelector('#contactInformation-permanentAddress-country'),
+      defaultValue: '{{ applicationValue(["contactInformation", "permanentAddress", "country"]) }}'
     })
   </script>
 {% endblock %}


### PR DESCRIPTION
It may be the case that the address where a candidate can currently be contacted is not the same as their usual residential address. For example:

* They want to be contacted at their term-time address, but live somewhere else in the country
* An international student is living in the UK currently, but has their permanent address in another country (or vice-versa)

While not definitive, collecting both contact and residential addresses can also help in the determination of fee status and domicile.

This PR allows candidates to enter a second permanent address, or have this be the same as the contact address they have already entered. See the [user journey in this diagram](https://lucid.app/lucidspark/5e95d0ca-8a69-4b14-9418-97f0e78048c6).