### PR TITLE
Update English hint text and examples for non-UK qualification

### DIFF
--- a/app/views/application/gcse/index.njk
+++ b/app/views/application/gcse/index.njk
@@ -37,7 +37,7 @@
               text: "Type of qualification"
             },
             hint: {
-              html: "For example, High school diploma, Higher Secondary School Certificate, <span lang=\"fr\">Baccalauréat Général</span>, <span lang=\"es\">Título de Bachiller</span>"
+              html: "For example, <span lang=\"fr\">Baccalauréat Général</span>, Secondary School Certificate (SSC), <span lang=\"es\">Título de Bachiller</span>, West African Senior School Certificate Examination (WASSCE)"
             }
           } | decorateApplicationAttributes(["gcse", id, "typeNonUk"])) }}
         {% endset %}
@@ -67,7 +67,7 @@
             }
           },
           hint: {
-            text: "This should be different from an English as a foreign language qualification."
+            text: "This should be a school qualification, not an English as a foreign language qualification."
           } if subject == "English",
           items: [{
             text: "GCSE"


### PR DESCRIPTION
Updated content based upon conversation with international recruitment team.

The intention here is to make the (somewhat hard-to-understand) distinction clearer between qualifications equivalent to GCSE English (English as a subject?) and qualifications in English as a foreign language, like TOEFL, ELTS, or English as taught in schools where English is not the national language.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/30665/131117780-08e02805-5ee7-4181-b071-a96e8a66f0da.png)

### After

![after](https://user-images.githubusercontent.com/30665/131117826-56f48d30-4884-4a01-9621-fd88c8a0ea00.png)
