### PR TITLE
Make it clear you can return to reference

### DIFF
--- a/app/views/admin/index.njk
+++ b/app/views/admin/index.njk
@@ -15,5 +15,6 @@
     <li><a href="/admin/flags">View feature flags</a></li>
     <li><a href="/admin/send-email">Send email</a></li>
     <li><a href="/admin/states">Mock application states</a></li>
+    <li><a href="/reference">Giving a reference flow</a></li>
   </ul>
 {% endblock %}

--- a/app/views/reference/comments.njk
+++ b/app/views/reference/comments.njk
@@ -2,7 +2,7 @@
 
 {% set formaction = referrer or "/reference/review" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Your reference for " + candidate_name %}
+{% set title = "Does " + candidate_name + " have the potential to teach?" %}
 {% set hasAccountLinks = false %}
 
 {% block pageNavigation %}
@@ -18,32 +18,22 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Your reference can be a maximum of 500 words. You can save and return later if you need more time. Return using the link in your email.</p>
-  <p class="govuk-body">When giving your reference try to cover the following, but do not worry if there are areas you cannot comment on:</p>
-  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-{% if type == "academic" %}
-    <li>
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Academic abilities</h2>
-      <p class="govuk-body">Does the candidate think critically and have good numeracy and literacy skills?</p>
-    </li>
-{% endif %}
-    <li>
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Teaching potential</h2>
-      <p class="govuk-body">Is the candidate emotionally resilient? Do they work well with others?</p>
-    </li>
-    <li>
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Reliability and professionalism</h2>
-      <p class="govuk-body">Can the candidate meet deadlines and manage their time?</p>
-    </li>
-    <li>
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Suitability to work with children</h2>
-      <p class="govuk-body">Does the candidate care about the wellbeing of children? </p>
-    </li>
-    <li>
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Transferable skills</h2>
-      <p class="govuk-body">What abilities would the candidate bring to teaching - for example, communication, creativity, project management?</p>
-    </li>
-  </ul>
+
+
+    <p class="govuk-body">You could comment on things like their:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      {% if type == "academic" %}
+        <li>academic skills</li>
+      {% endif %}
+      <li>communication skills</li>
+      <li>reliability and professionalism</li>
+      <li>ability to work with children</li>
+      <li>transferable skills</li>
+    </ul>
+
+    <p class="govuk-body">You can write up to 500 words. </p>
+    <p class="govuk-body">If you need more time, save and return later using the link in your email.</p>
 
   {{ govukCharacterCount({
     id: "reference-comments",

--- a/app/views/reference/comments.njk
+++ b/app/views/reference/comments.njk
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Your reference can be a maximum of 500 words. You can save and return later if you need more time. Return using the link sent to your email.</p>
+  <p class="govuk-body">Your reference can be a maximum of 500 words. You can save and return later if you need more time. Return using the link in your email.</p>
   <p class="govuk-body">When giving your reference try to cover the following, but do not worry if there are areas you cannot comment on:</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
 {% if type == "academic" %}

--- a/app/views/reference/comments.njk
+++ b/app/views/reference/comments.njk
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Complete your reference in one sitting. You cannot save it and come back to it later.</p>
+  <p class="govuk-body">Your reference can be a maximum of 300 words. You can save a draft and return later using the link sent to your email.</p>
   <p class="govuk-body">When giving your reference try to cover the following, but do not worry if there are areas you cannot comment on:</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
 {% if type == "academic" %}

--- a/app/views/reference/comments.njk
+++ b/app/views/reference/comments.njk
@@ -58,6 +58,6 @@
   }) }}
 
   {{ govukButton({
-    text: "Continue"
+    text: "Save and continue"
   }) }}
 {% endblock %}

--- a/app/views/reference/comments.njk
+++ b/app/views/reference/comments.njk
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Your reference can be a maximum of 300 words. You can save a draft and return later using the link sent to your email.</p>
+  <p class="govuk-body">Your reference can be a maximum of 500 words. You can save and return later if you need more time. Return using the link sent to your email.</p>
   <p class="govuk-body">When giving your reference try to cover the following, but do not worry if there are areas you cannot comment on:</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
 {% if type == "academic" %}
@@ -53,11 +53,11 @@
       text: "Your reference",
       classes: "govuk-label--m govuk-!-margin-top-6"
     },
-    maxwords: 300,
+    maxwords: 500,
     rows: 15
   }) }}
 
   {{ govukButton({
-    text: "Save and continue"
+    text: "Save"
   }) }}
 {% endblock %}

--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -56,6 +56,6 @@
   }) }}
 
   {{ govukButton({
-    text: "Continue"
+    text: "Save and continue"
   }) }}
 {% endblock %}

--- a/app/views/reference/review.njk
+++ b/app/views/reference/review.njk
@@ -18,6 +18,8 @@
     {% set safeguardingValue = data.reference.safeguarding.concern %}
   {% endif %}
 
+  <p class="govuk-body">If you're not ready to submit yet, you can return using the link in your email.</p>
+
   {{ govukSummaryList({
     rows: [{
       key: {
@@ -63,10 +65,6 @@
       }
     }]
   }) }}
-
-  <p class="govuk-body">Are you ready to submit this reference? Once you’ve submitted it you will no longer be able to edit it.</p>
-
-  <p class="govuk-body">If you need more time you can come back to this reference using the link in your email.</p>
 
   {{ govukButton({
     text: "Submit reference"

--- a/app/views/reference/review.njk
+++ b/app/views/reference/review.njk
@@ -5,18 +5,6 @@
 {% set title = "Check your answers before submitting your reference" %}
 {% set hasAccountLinks = false %}
 
-{% block pageNavigation %}
-  {% if referrer %}
-    {{ govukBackLink({
-      href: referrer
-    }) }}
-  {% else %}
-    {{ govukBackLink({
-      href: "/reference/comments"
-    }) }}
-  {% endif %}
-{% endblock %}
-
 {% block primary %}
   {% if data.reference.relationship.correct == "Yes" %}
     {% set relationshipValue = "Confirmed by referee" %}

--- a/app/views/reference/review.njk
+++ b/app/views/reference/review.njk
@@ -2,7 +2,7 @@
 
 {% set formaction = "/reference/confirmation" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Check your answers before submitting your reference" %}
+{% set title = "Your reference for " + candidate_name %}
 {% set hasAccountLinks = false %}
 
 {% block primary %}
@@ -63,6 +63,10 @@
       }
     }]
   }) }}
+
+  <p class="govuk-body">Are you ready to submit this reference? Once you’ve submitted it you will no longer be able to edit it.</p>
+
+  <p class="govuk-body">If you need more time you can come back to this reference using the link in your email.</p>
 
   {{ govukButton({
     text: "Submit reference"

--- a/app/views/reference/safeguarding.njk
+++ b/app/views/reference/safeguarding.njk
@@ -49,6 +49,6 @@
   }) }}
 
   {{ govukButton({
-    text: "Continue"
+    text: "Save and continue"
   }) }}
 {% endblock %}


### PR DESCRIPTION
We currently tell referees that they need to complete the reference in a "one sitting". However they _can_ save and come back to it at any time, using the original link sent to their email.

Feedback from referees has indicated that they find the requirement to complete the reference in a single sitting to be stressful, especially given that the reference takes longer than they initially expect.  Some referees may work around this by copying and pasting to and from a separate file, but this can be cumbersome, and means they might not see the word count straight away.

To address this, we are changing the content to make clear that they can return to the form after saving it. The buttons are also relabelled from "Continue" to "Save and continue". However the button on the page with the 500 word textarea is just labelled "Save" so that it's clear you can save this even if you aren't ready to continue.

The check your answers page also has new content to make it clearer that referees can exit at this page and return to continue, rather than submit it now, and the title changed from "Check your answers before submitting your reference" to "Your reference for [candidate name]".

The title of the reference page has changed from "Your reference for [candidate name]" to a question: "Does Jane Doe have the potential to teach?". This is to distinguish it from the last page, and because elsewhere we use "reference" to refer to the whole journey, not just this question.

The bullet points on the reference page have also been revised to be more succinct, and more in keeping with the style guide. (Previously the bullets contained headings and paragraphs).


We should monitor this to see if it has any impact on the average time it takes referees to complete a reference, as one possible negative side-effect is referees taking longer to submit instead of rushing a reference because of the perceived "single sitting" requirement.

We are also separately changing the content of the referee email: https://github.com/DFE-Digital/apply-for-teacher-training/pull/5582

## Before

<img width="825" alt="Screenshot 2021-09-15 at 15 12 18" src="https://user-images.githubusercontent.com/30665/133449689-26453d2b-782d-4649-96a2-b53ccdb67eb7.png">

<img width="243" alt="Screenshot 2021-09-14 at 14 39 01" src="https://user-images.githubusercontent.com/30665/133268043-44f3a678-e07f-4f10-a032-dd9e137225e4.png">

<img width="803" alt="Screenshot 2021-09-15 at 14 15 09" src="https://user-images.githubusercontent.com/30665/133440055-acecdfac-8424-4efe-96cd-b5b7f3e9909f.png">

## After

<img width="779" alt="Screenshot 2021-09-15 at 15 12 01" src="https://user-images.githubusercontent.com/30665/133449726-3a8fa880-1c52-4fe4-90bc-af601cdeb41f.png">

<img width="267" alt="Screenshot 2021-09-14 at 14 38 53" src="https://user-images.githubusercontent.com/30665/133268068-b4bef8e6-c455-4734-9610-1d74821900b7.png">

<img width="711" alt="Screenshot 2021-09-15 at 14 39 43" src="https://user-images.githubusercontent.com/30665/133444017-d2168483-0567-4bca-9334-0db8e564ccd5.png">

