### PR TITLE
Add institutions from the Register list

### DIFF
--- a/app/data/degree-institutions.js
+++ b/app/data/degree-institutions.js
@@ -120,11 +120,11 @@ module.exports = [
     "dttp_id": "4c71f34a-2887-e711-80d8-005056ac45bb"
   },
   {
-    "name": "University of St Mark and St John",
-    "suggestion_synonyms": [],
+    "name": "Plymouth Marjon University",
+    "suggestion_synonyms": ["University of St Mark and St John"],
     "match_synonyms": [],
     "hesa_itt_code": "14",
-    "dttp_id": null
+    "dttp_id": "3a71f34a-2887-e711-80d8-005056ac45bb"
   },
   {
     "name": "Dartington College of Arts",
@@ -653,7 +653,7 @@ module.exports = [
   },
   {
     "name": "University of South Wales",
-    "suggestion_synonyms": [],
+    "suggestion_synonyms": ["University of Glamorgan"],
     "match_synonyms": [],
     "hesa_itt_code": "90",
     "dttp_id": "8723a753-7042-e811-80ff-3863bb3640b8"
@@ -1257,7 +1257,7 @@ module.exports = [
   },
   {
     "name": "Cardiff University",
-    "suggestion_synonyms": [],
+    "suggestion_synonyms": ["University College Cardiff"],
     "match_synonyms": [],
     "hesa_itt_code": "179",
     "dttp_id": "0ff35f0b-7042-e811-80ff-3863bb3640b8"
@@ -2460,5 +2460,56 @@ module.exports = [
     "match_synonyms": [],
     "hesa_itt_code": null,
     "dttp_id": "3d0517a7-a441-e811-80fd-3863bb349ac0"
-  }
-]
+  },
+  {
+    "name": "NCG",
+    "suggestion_synonyms": [
+      "Newcatle College Group",
+      "Newcastle College"
+    ],
+    "match_synonyms": [],
+    "hesa_itt_code": null,
+    "dttp_id": "20e5a08c-ee97-e711-80d8-005056ac45bb"
+  },
+  {
+    "name": "City College Norwich",
+    "suggestion_synonyms": [
+      "Norwich City College",
+      "Norwich City College of Further and Higher Education"
+    ],
+    "match_synonyms": [],
+    "hesa_itt_code": null,
+    "dttp_id": "3efe7322-e897-e711-80d8-005056ac45bb"
+  },
+  {
+    "name": "University of Wales",
+    "suggestion_synonyms": [
+    ],
+    "match_synonyms": ["University of Wales (central functions)"],
+    "hesa_itt_code": null,
+    "dttp_id": "6a228041-7042-e811-80ff-3863bb3640b8"
+  },
+  {
+    "name": "University of Glamorgan",
+    "suggestion_synonyms": [],
+    "match_synonyms": [],
+    "hesa_itt_code": null,
+    "dttp_id": null,
+    "comment": "Merged with Newport to become University of South Wales in 2013"
+  },
+  {
+    "name": "University of London",
+    "suggestion_synonyms": [],
+    "match_synonyms": [],
+    "hesa_itt_code": null,
+    "dttp_id": "0d791c39-3fa2-e811-812b-5065f38ba241",
+    "comment": "Constituent colleges gained the ability to award their own degrees in around 2018."
+  },
+  {
+    "name": "West Suffolk College",
+    "suggestion_synonyms": [],
+    "match_synonyms": [],
+    "hesa_itt_code": null,
+    "dttp_id": "82ff7322-e897-e711-80d8-005056ac45bb",
+    "comment": ""
+  }]


### PR DESCRIPTION
This adds several institutions which are currently in [Register’s list](https://github.com/DFE-Digital/register-trainee-teachers/blob/master/app/lib/dttp/code_sets/institutions.rb), but aren’t in [Apply's list](https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/config/initializers/qualifications/hesa_degree_institutions.rb):

* NCG (Newcastle College Group)
* City College Norwich
* University of Wales
* University of Glamorgan
* University of London
* West Suffolk College

In addition, the DTTP id for University of St Mark and St John has been added, and its name has been changed to its student-facing name of "Plymouth Marjon University", with "University of St Mark and St John" becoming a synonym.


"University of Wales" and "University of London" both have complicated histories, where sometimes their constituent bodies award their own degrees and sometimes the parent body has. Given this, it makes sense to list both.