### PR TITLE
Update name of Sotheby

### DIFF
--- a/app/data/degree-institutions.js
+++ b/app/data/degree-institutions.js
@@ -2219,8 +2219,10 @@ module.exports = [
     "dttp_id": "d13e182c-1425-ec11-b6e6-000d3adf095a"
   },
   {
-    "name": "Institute Of Art - London",
-    "suggestion_synonyms": [],
+    "name": "Sotheby’s Institute of Art",
+    "suggestion_synonyms": [
+      "Institute Of Art - London"
+    ],
     "match_synonyms": [],
     "hesa_itt_code": "405",
     "dttp_id": "5b3e182c-1425-ec11-b6e6-000d3adf095a"


### PR DESCRIPTION
"Sotheby’s Institute of Art" seems to be its public facing name (see https://www.sothebysinstitute.com).