### PR TITLE
Remove "/Education" degree types

### DIFF
--- a/app/data/degree-types.js
+++ b/app/data/degree-types.js
@@ -441,38 +441,6 @@ module.exports = [
     "hesa_itt_code": "1"
   },
   {
-    "name": "BSc/Education",
-    "abbreviation": null,
-    "synonyms": [],
-    "level": "6",
-    "dqt_id": "c5695652-c197-e711-80d8-005056ac45bb",
-    "hesa_itt_code": "3"
-  },
-  {
-    "name": "BTech/Education",
-    "abbreviation": null,
-    "synonyms": [],
-    "level": "6",
-    "dqt_id": "c9695652-c197-e711-80d8-005056ac45bb",
-    "hesa_itt_code": "5"
-  },
-  {
-    "name": "BA/Education",
-    "abbreviation": null,
-    "synonyms": [],
-    "level": "6",
-    "dqt_id": "c9695652-c197-e711-80d8-005056ac45bb",
-    "hesa_itt_code": "7"
-  },
-  {
-    "name": "BA Combined Studies/Education of the Deaf",
-    "abbreviation": null,
-    "synonyms": [],
-    "level": "6",
-    "dqt_id": "d1695652-c197-e711-80d8-005056ac45bb",
-    "hesa_itt_code": "9"
-  },
-  {
     "name": "BA with intercalated PGCE",
     "abbreviation": null,
     "synonyms": [],


### PR DESCRIPTION
We think these aren't degree titles/types, but represent a combination of degree type + subject, for reporting purposes to HESA.

These can be mapped to separately, if required, through combining degree type with the subject code.

They shouldn't appear in the degree type autocomplete, as this can confuse users into thinking they should enter their degree subject along with the type.