### PR TITLE
Tweak to decline reference flow

### DIFF
--- a/app/views/reference/decline.njk
+++ b/app/views/reference/decline.njk
@@ -6,8 +6,8 @@
 {% set hasAccountLinks = false %}
 
 {% block primary %}
-  <p class="govuk-body">Teacher training courses can fill up quickly, and candidates need 2 references to apply.</p>
-  <p class="govuk-body">{{ candidate_name }} will be able to submit the application quicker if you give a reference.</p>
+
+  <p class="govuk-body">Declining {{ candidate_name }}’s reference request may delay their application and make it harder for them to get onto teacher training.</p>
 
   {{ govukRadios({
     fieldset: {


### PR DESCRIPTION
We have some evidence (from support) of referees declining references by mistake.

We think this is because the email contains two links, and they click on the second one (to decline), and then select "Yes, I’m sure" without reading the rest of the page (or skim-reading it or mis-interpreting it).

We hope to avoid this by changing the wording of the radio buttons so that:

* the "Yes" action corresponds to giving a reference instead of declining
* the radio button labels contain a full answer, so that they can be understood without reading the question above

## Before

<img width="775" alt="Screenshot 2021-10-15 at 12 41 15" src="https://user-images.githubusercontent.com/30665/137504529-43a37a8b-3a83-409b-80fb-49c3a62a6fcf.png">

## After

<img width="786" alt="Screenshot 2021-10-18 at 11 27 09" src="https://user-images.githubusercontent.com/30665/137714138-c3f5efe2-00df-43c6-9991-1478648599b2.png">


