### PR TITLE
Bugfix: references flow

### DIFF
--- a/app/views/application/references/review.njk
+++ b/app/views/application/references/review.njk
@@ -85,7 +85,7 @@
       {{ govukButton({
         classes: "govuk-button--secondary",
         text: "Request another reference",
-        href: "/application/" + applicationId + "/references/add?referrer=" + referrer
+        href: "/application/" + applicationId + "/references/add"
       }) }}
     </div>
 


### PR DESCRIPTION
The referrer string shouldn't be added here, as it prevents the flow from working (redirected back to the review page after answering the first question).