### PR TITLE
Simplify "other qualifications" flow

### DIFF
--- a/app/routes/application/other-qualifications.js
+++ b/app/routes/application/other-qualifications.js
@@ -67,16 +67,6 @@ module.exports = router => {
     const { year, org, type } = application.otherQualifications[id]
     const { typeUk } = application.otherQualifications[id]
 
-    if (next === 'add-type') {
-      application.otherQualifications[nextId] = {
-        year,
-        org,
-        type,
-        typeUk
-      }
-      res.redirect(referrer || `/application/${applicationId}/other-qualifications/${nextId}/details`)
-    } else {
-      res.redirect(referrer || `/application/${applicationId}/other-qualifications/${next}`)
-    }
+    res.redirect(referrer || `/application/${applicationId}/other-qualifications/${next}`)
   })
 }

--- a/app/views/_includes/item/other-qualifications.njk
+++ b/app/views/_includes/item/other-qualifications.njk
@@ -2,112 +2,89 @@
 {% set qualifications = otherQualifications | toArray | selectattr("id") %}
 {% set itemName = "other qualifications" if international else "A levels and other qualifications" %}
 
-{% if applicationValue(["otherQualificationsDisclose"]) == "No" %}
+{% for item in qualifications %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
+    headingLevel: 3,
+    titleText: item.type,
+    actions: {
+      items: [{
+        href: applicationPath + "/other-qualifications/" + item.id + "/delete?referrer=" + referrer,
+        text: "Delete qualification"
+      }]
+    } if canAmend,
     html: govukSummaryList({
       rows: [{
         key: {
-          text: "Do you want to add any " + itemName
+          text: "Type of qualification"
         },
         value: {
-          text: applicationValue(["otherQualificationsDisclose"])
+          text: item.typeUk or item.typeNonUk or item.type or "Not entered"
         },
         actions: {
           items: [{
-            href: applicationPath + "/other-qualifications/add?referrer=" + referrer,
+            href: applicationPath + "/other-qualifications/" + item.id + "?referrer=" + referrer,
             text: "Change",
-            visuallyHiddenText: "if you want to add A levels or other qualifications"
+            visuallyHiddenText: "year"
+          }]
+        } if canAmend
+      }, {
+        key: {
+          text: "Subject" + (" (optional)" if item.type == "Non-UK qualification")
+        },
+        value: {
+          text: item.subject or "Not entered"
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
+            text: "Change",
+            visuallyHiddenText: "year"
+          }]
+        } if canAmend
+      }, {
+        key: {
+          text: "Country"
+        },
+        value: {
+          text: item.country
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
+            text: "Change",
+            visuallyHiddenText: "country"
+          }]
+        } if canAmend
+      } if item.country, {
+        key: {
+          text: "Year awarded"
+        },
+        value: {
+          text: item.year or "Not entered"
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
+            text: "Change",
+            visuallyHiddenText: "year"
+          }]
+        } if canAmend
+      }, {
+        key: {
+          text: "Grade (optional)"
+        },
+        value: {
+          text: item.grade or "Not entered"
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
+            text: "Change",
+            visuallyHiddenText: "grade"
           }]
         } if canAmend
       }]
     })
-  }) }}
-{% else %}
-  {% for item in qualifications %}
-    {{ appSummaryCard({
-      classes: "govuk-!-margin-bottom-6",
-      headingLevel: 3,
-      titleText: item.type,
-      actions: {
-        items: [{
-          href: applicationPath + "/other-qualifications/" + item.id + "/delete?referrer=" + referrer,
-          text: "Delete qualification"
-        }]
-      } if canAmend,
-      html: govukSummaryList({
-        rows: [{
-          key: {
-            text: "Type of qualification"
-          },
-          value: {
-            text: item.typeUk or item.typeNonUk or item.type or "Not entered"
-          },
-          actions: {
-            items: [{
-              href: applicationPath + "/other-qualifications/" + item.id + "?referrer=" + referrer,
-              text: "Change",
-              visuallyHiddenText: "year"
-            }]
-          } if canAmend
-        }, {
-          key: {
-            text: "Subject" + (" (optional)" if item.type == "Non-UK qualification")
-          },
-          value: {
-            text: item.subject or "Not entered"
-          },
-          actions: {
-            items: [{
-              href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
-              text: "Change",
-              visuallyHiddenText: "year"
-            }]
-          } if canAmend
-        }, {
-          key: {
-            text: "Country"
-          },
-          value: {
-            text: item.country
-          },
-          actions: {
-            items: [{
-              href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
-              text: "Change",
-              visuallyHiddenText: "country"
-            }]
-          } if canAmend
-        } if item.country, {
-          key: {
-            text: "Year awarded"
-          },
-          value: {
-            text: item.year or "Not entered"
-          },
-          actions: {
-            items: [{
-              href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
-              text: "Change",
-              visuallyHiddenText: "year"
-            }]
-          } if canAmend
-        }, {
-          key: {
-            text: "Grade (optional)"
-          },
-          value: {
-            text: item.grade or "Not entered"
-          },
-          actions: {
-            items: [{
-              href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
-              text: "Change",
-              visuallyHiddenText: "grade"
-            }]
-          } if canAmend
-        }]
-      })
-    }) if item.type != "None" }}
-  {% endfor %}
-{% endif %}
+  }) if item.type != "None" }}
+{% endfor %}

--- a/app/views/_includes/review/other-qualifications.njk
+++ b/app/views/_includes/review/other-qualifications.njk
@@ -1,5 +1,8 @@
 {% set completed = applicationValue(["completed", "otherQualifications"]) == "Yes" %}
 
+{% set entered = applicationValue(["otherQualificationsDisclose"]) %}
+{% set international = applicationValue(["candidate", "otherNationality1"]) %}
+
 {{ appSuggestion({
   id: "otherQualifications",
   title: "A levels and other qualifications not marked as complete",
@@ -12,4 +15,36 @@
   }
 }) if not completed and showIncomplete }}
 
-{% include "_includes/item/other-qualifications.njk" %}
+{% if entered == "No" %}
+
+
+  {% set summaryCardHtml %}
+
+    {{ govukSummaryList({
+      classes: "app-summary",
+      rows: [{
+        key: {
+          text: "Do you have any " + ("A levels and " if not international) + "other qualifications you’d like to add?"
+        },
+        value: {
+          text: "No"
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/other-qualifications",
+            text: "Change",
+            visuallyHiddenText: "explanation"
+          }]
+        }
+      }]
+    }) }}
+  {% endset %}
+
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    html: summaryCardHtml
+  }) }}
+
+{% else %}
+  {% include "_includes/item/other-qualifications.njk" %}
+{% endif %}

--- a/app/views/_includes/review/other-qualifications.njk
+++ b/app/views/_includes/review/other-qualifications.njk
@@ -1,45 +1,15 @@
-{% set completed = applicationValue(["completed", "otherQualifications"]) %}
-{% set entered = applicationValue(["otherQualificationsDisclose"]) %}
+{% set completed = applicationValue(["completed", "otherQualifications"]) == "Yes" %}
 
-{% if not entered %}
-  {{ appSuggestion({
-    id: "otherQualifications",
-    title: "A levels or other qualifications not entered",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Enter your other qualifications",
-        href: applicationPath + "/other-qualifications/add"
-      }]
-    }
-  }) }}
-{% else %}
-  {% set insetTextHtml %}
-    <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
-    <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
-    {{ govukButton({
-      text: "Add another qualification",
-      classes: "govuk-button--secondary",
-      href: applicationPath + "/other-qualifications/add"
-    }) }}
-  {% endset %}
+{{ appSuggestion({
+  id: "otherQualifications",
+  title: "A levels and other qualifications not marked as complete",
+  warning: true if errorList,
+  actions: {
+    items: [{
+      text: "Complete your other qualifications",
+      href: applicationPath + "/other-qualifications/review"
+    }]
+  }
+}) if not completed and showIncomplete }}
 
-  {{ govukInsetText({
-    classes: "govuk-!-width-two-thirds govuk-!-margin-top-0",
-    html: insetTextHtml
-  }) if applicationValue(["otherQualificationsDisclose"]) == "No" and not showIncomplete }}
-
-  {{ appSuggestion({
-    id: "otherQualifications",
-    title: "A levels and other qualifications not marked as complete",
-    warning: true if errorList,
-    actions: {
-      items: [{
-        text: "Complete your other qualifications",
-        href: applicationPath + "/other-qualifications/review"
-      }]
-    }
-  }) if not completed and showIncomplete }}
-
-  {% include "_includes/item/other-qualifications.njk" %}
-{% endif %}
+{% include "_includes/item/other-qualifications.njk" %}

--- a/app/views/_includes/review/other-qualifications.njk
+++ b/app/views/_includes/review/other-qualifications.njk
@@ -24,7 +24,7 @@
       classes: "app-summary",
       rows: [{
         key: {
-          text: "Do you have any " + ("A levels and " if not international) + "other qualifications you’d like to add?"
+          text: "Do you want to add any " + ("A levels or " if not international) + "other qualifications?"
         },
         value: {
           text: "No"

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -1,8 +1,3 @@
-  </div>
-</div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-
   {{ appSuggestion({
     id: "referees",
     title: "You need 2 references before you can submit your application",

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -216,7 +216,7 @@
         }
       } if hasPrimaryChoices() or applicationValue(["gcse", "science"]), {
         text: "Other qualifications" if international else "A levels and other qualifications",
-        href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["otherQualificationsDisclose"]) else "/add"),
+        href: applicationPath + "/other-qualifications" + "/review",
         id: "other-qualifications",
         tag: {
           classes: tagClassesForSection(completed=applicationValue(["completed", "otherQualifications"])),

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -216,7 +216,7 @@
         }
       } if hasPrimaryChoices() or applicationValue(["gcse", "science"]), {
         text: "Other qualifications" if international else "A levels and other qualifications",
-        href: applicationPath + "/other-qualifications" + "/review",
+        href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["otherQualificationsDisclose"]) else ""),
         id: "other-qualifications",
         tag: {
           classes: tagClassesForSection(completed=applicationValue(["completed", "otherQualifications"])),

--- a/app/views/application/other-qualifications/details.njk
+++ b/app/views/application/other-qualifications/details.njk
@@ -29,14 +29,14 @@
     or type == "A level"
   %}
     <div class="govuk-form-group">
-      <label class="govuk-label govuk-label--m" for="otherQualifications-{{ id }}-subject">Subject</label>
+      <label class="govuk-label govuk-label--s" for="otherQualifications-{{ id }}-subject">Subject</label>
       <div id="subject-autocomplete-container"></div>
     </div>
   {% else %}
     {{ govukInput({
       label: {
         text: "Subject",
-        classes: "govuk-label--m"
+        classes: "govuk-label--s"
       }
     } | decorateApplicationAttributes(["otherQualifications", id, "subject"])) }}
   {% endif %}
@@ -45,7 +45,7 @@
     {{ appAutocomplete({
       label: {
         text: "Country where you studied",
-        classes: "govuk-label--m"
+        classes: "govuk-label--s"
       },
       items: countries
     } | decorateApplicationAttributes(["otherQualifications", id, "country"])) }}
@@ -54,7 +54,7 @@
   {{ govukInput({
     label: {
       text: "Grade (optional)",
-      classes: "govuk-label--m"
+      classes: "govuk-label--s"
     },
     hint: {
       text: "For example, ‘C’, ‘CD’, ‘4’ or ‘4-3’"
@@ -65,41 +65,13 @@
   {{ govukInput({
     label: {
       text: "Year qualification was awarded",
-      classes: "govuk-label--m"
+      classes: "govuk-label--s"
     },
     hint: {
       text: "For example, 1998"
     },
     classes: "govuk-input--width-4"
   } | decorateApplicationAttributes(["otherQualifications", id, "year"])) }}
-
-  {# Only ask if want to add another if:
-    * not editing an existing item
-    * not referred from a review page (which has an ‘Add another…’ button)
-    * feature flag enabled
-  #}
-  {% if action != "edit" and not referrer %}
-    {{ govukRadios({
-      name: "next",
-      fieldset: {
-        legend: {
-          text: "Do you want to add another qualification?",
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [{
-        value: "add-type",
-        text: "Yes, add another " + qualificationName + " qualification"
-      }, {
-        value: "add",
-        text: "Yes, add a different qualification"
-      }, {
-        value: "review",
-        text: "No, not at the moment",
-        checked: true
-      }]
-    }) }}
-  {% endif %}
 
   {{ govukButton({
     text: "Save and continue"

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -1,22 +1,15 @@
-{% extends "_form.njk" %}
+{% extends "_form-question.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set international = applicationValue(["candidate", "otherNationality1"]) %}
-{% set title = "Other qualifications" if international else "A levels and other qualifications" %}
+{% set title = "What type of qualification is it?" %}
 {% set itemName = "other qualifications" if international else "A levels and other qualifications" %}
 {% set allowsFeedback = true %}
 
 {% block pageNavigation %}
-  {% if referrer %}
-    {{ govukBackLink({
-      href: referrer
-    }) }}
-  {% else %}
-    {{ govukBackLink({
-      href: "/application/" + applicationId,
-      text: "Back to application"
-    }) }}
-  {% endif %}
+  {{ govukBackLink({
+      href: "/application/" + applicationId + "/other-qualifications/review"
+  }) }}
 {% endblock %}
 
 {% block primary %}
@@ -42,8 +35,9 @@
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "What type of qualification do you want to add?",
-        classes: "govuk-label--m"
+        text: "What type of qualification is it?",
+        classes: "govuk-label--l",
+        isPageHeading: true
       },
       attributes: {
         "data-module": "clear-hidden"
@@ -60,25 +54,17 @@
       text: "GCSE"
     }, {
       value: "Other UK qualification",
-      text: "Other UK qualification",
+      text: "Another UK qualification",
       conditional: {
         html: otherUkConditionalHtml
       }
     }, {
       value: "Non-UK qualification",
-      text: "Non-UK qualification",
+      text: "A non-UK qualification",
       conditional: {
         html: nonUkConditionalHtml
       }
-    }, {
-      divider: "or"
-    } if noQualificationsEntered, {
-      value: "None",
-      text: "I do not want to add any " + itemName,
-      hint: {
-        text: "Providers look at " + itemName + " for evidence of subject knowledge not covered in your degree or work history"
-      }
-    } if noQualificationsEntered]
+    }]
   } | decorateApplicationAttributes(["otherQualifications", id, "type"])) }}
 
   {{ govukInput({

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -1,112 +1,51 @@
-{% extends "_form-question.njk" %}
+{% extends "_form.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set international = applicationValue(["candidate", "otherNationality1"]) %}
-{% set title = "What type of qualification is it?" %}
+{% set title = "Other qualifications" if international else "A levels and other qualifications" %}
 {% set itemName = "other qualifications" if international else "A levels and other qualifications" %}
 {% set allowsFeedback = true %}
+{% set formaction = applicationPath + "/other-qualifications/answer" %}
 
 {% block pageNavigation %}
-  {{ govukBackLink({
-      href: "/application/" + applicationId + "/other-qualifications/review"
-  }) }}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      href: "/application/" + applicationId,
+      text: "Back to application"
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block primary %}
-  {% set otherUkConditionalHtml %}
-    <div class="govuk-form-group">
-      <label class="govuk-label govuk-label--s" for="otherQualifications-{{ id }}-typeUk">Qualification name</label>
-      <div id="type-uk-autocomplete-container"></div>
-    </div>
-  {% endset %}
 
-  {% set nonUkConditionalHtml %}
-    {{ govukInput({
-      label: {
-        text: "Qualification name",
-        classes: "govuk-label--s"
-      },
-      hint: {
-        html: "For example, High school diploma, Higher Secondary School Certificate, <span lang=\"fr\">Baccalauréat Général</span>, <span lang=\"es\">Título de Bachiller</span>"
-      }
-    } | decorateApplicationAttributes(["otherQualifications", id, "typeNonUk"])) }}
-  {% endset %}
+  <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
+  <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
 
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "What type of qualification is it?",
-        classes: "govuk-label--l",
-        isPageHeading: true
+        text: "Do you want to add " + ("a qualficaiton" if international else "an A level or other qualification") + "?",
+        classes: "govuk-label--m"
       },
       attributes: {
         "data-module": "clear-hidden"
       }
     },
     items: [{
-      value: "A level",
-      text: "A level"
+      value: "Yes",
+      text: "Yes"
     }, {
-      value: "AS level",
-      text: "AS level"
-    }, {
-      value: "GCSE",
-      text: "GCSE"
-    }, {
-      value: "Other UK qualification",
-      text: "Another UK qualification",
-      conditional: {
-        html: otherUkConditionalHtml
-      }
-    }, {
-      value: "Non-UK qualification",
-      text: "A non-UK qualification",
-      conditional: {
-        html: nonUkConditionalHtml
-      }
+      value: "No",
+      text: "No, I don’t want to add any other qualifications"
     }]
-  } | decorateApplicationAttributes(["otherQualifications", id, "type"])) }}
-
-  {{ govukInput({
-    value: "Yes",
-    type: "hidden"
   } | decorateApplicationAttributes(["otherQualificationsDisclose"])) }}
 
-  {% set internationalConditionalHtml %}
-    {{ appAutocomplete({
-      label: {
-        text: "In which country is your institution based?"
-      },
-      items: countries
-    } | decorateApplicationAttributes(["otherQualifications", id, "country"])) }}
-  {% endset %}
 
   {{ govukButton({
     text: "Continue"
   }) }}
-{% endblock %}
-
-{% block pageScripts %}
-  <script src="/public/javascripts/autocomplete.min.js"></script>
-  <script>
-    accessibleAutocomplete({
-      element: document.querySelector('#type-uk-autocomplete-container'),
-      id: 'otherQualifications-{{ id }}-typeUk',
-      name: "applications[{{ applicationId }}][otherQualifications][{{ id }}][typeUk]",
-      defaultValue: '{{ applicationValue(["otherQualifications", id, "typeUk"]) }}',
-      minLength: 2,
-      placeholder: false,
-      showNoOptionsFound: false,
-      source: [
-        'BTEC',
-        'O level',
-        'NVQ',
-        'Scottish National 5',
-        'Scottish Higher',
-        'Scottish Advanced Higher',
-        'SVQ',
-        'VRQ'
-      ]
-    })
-  </script>
 {% endblock %}

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -22,13 +22,14 @@
 
 {% block primary %}
 
-  <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
-  <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
+  <p class="govuk-body">Adding A levels and other qualifications can make your application stronger.</p>
+
+  <p class="govuk-body">Training providers may ask to see them later if you do not include them in your application.</p>
 
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "Do you want to add " + ("a qualficaiton" if international else "an A level or other qualification") + "?",
+        text: "Do you want to add " + ("a qualficaiton" if international else "any A levels or other qualifications") + "?",
         classes: "govuk-label--m"
       },
       attributes: {
@@ -40,7 +41,7 @@
       text: "Yes"
     }, {
       value: "No",
-      text: "No, I do not want to add any other qualifications"
+      text: "No, I do not want to add any A levels or other qualifications"
     }]
   } | decorateApplicationAttributes(["otherQualificationsDisclose"])) }}
 

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -40,7 +40,7 @@
       text: "Yes"
     }, {
       value: "No",
-      text: "No, I don’t want to add any other qualifications"
+      text: "No, I do not want to add any other qualifications"
     }]
   } | decorateApplicationAttributes(["otherQualificationsDisclose"])) }}
 

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -22,14 +22,14 @@
 
 {% block primary %}
 
-  <p class="govuk-body">Adding A levels and other qualifications can make your application stronger.</p>
+  <p class="govuk-body">Adding {{ "A levels and " if not international }} other qualifications can make your application stronger.</p>
 
   <p class="govuk-body">Training providers may ask to see them later if you do not include them in your application.</p>
 
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "Do you want to add " + ("a qualficaiton" if international else "any A levels or other qualifications") + "?",
+        text: "Do you want to add " + ("a qualification" if international else "any A levels or other qualifications") + "?",
         classes: "govuk-label--m"
       },
       attributes: {
@@ -41,7 +41,7 @@
       text: "Yes"
     }, {
       value: "No",
-      text: "No, I do not want to add any A levels or other qualifications"
+      text: "No, I do not want to add " + ("a qualification" if international else "any A levels or other qualifications") + ""
     }]
   } | decorateApplicationAttributes(["otherQualificationsDisclose"])) }}
 

--- a/app/views/application/other-qualifications/review.njk
+++ b/app/views/application/other-qualifications/review.njk
@@ -7,6 +7,8 @@
 {% set allowsFeedback = true %}
 {% set referrer = applicationPath + "/other-qualifications/review" %}
 {% set canAmend = true %}
+{% set otherQualifications = applicationValue(["otherQualifications"]) | toArray %}
+
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -16,7 +18,14 @@
 {% endblock %}
 
 {% block primary %}
+  <div class="govuk-!-width-two-thirds">
+    <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
+    <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
+  </div>
+
   {% include "_includes/review/other-qualifications.njk" %}
+
+  {{ govukButton({text: "Add qualification", href: applicationPath + "/other-qualifications/add", classes: "govuk-button--secondary"}) }}
 
   {{ govukRadios({
     fieldset: {

--- a/app/views/application/other-qualifications/review.njk
+++ b/app/views/application/other-qualifications/review.njk
@@ -18,14 +18,24 @@
 {% endblock %}
 
 {% block primary %}
-  <div class="govuk-!-width-two-thirds">
-    <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
-    <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
-  </div>
 
-  {% include "_includes/review/other-qualifications.njk" %}
+    {% if applicationValue(["otherQualificationsDisclose"]) == "No" %}
 
-  {{ govukButton({text: "Add qualification", href: applicationPath + "/other-qualifications/add", classes: "govuk-button--secondary"}) }}
+      {% include "_includes/review/other-qualifications.njk" %}
+
+    {% else %}
+
+      <div class="govuk-!-width-two-thirds">
+        <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
+        <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
+      </div>
+
+      {{ govukButton({text: "Add another qualification", href: applicationPath + "/other-qualifications/add", classes: "govuk-button--secondary"}) }}
+
+      {% include "_includes/review/other-qualifications.njk" %}
+
+    {% endif %}
+
 
   {{ govukRadios({
     fieldset: {

--- a/app/views/application/other-qualifications/review.njk
+++ b/app/views/application/other-qualifications/review.njk
@@ -26,8 +26,8 @@
     {% else %}
 
       <div class="govuk-!-width-two-thirds">
-        <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
-        <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
+        <p class="govuk-body">Adding A levels and other qualifications can make your application stronger.</p>
+        <p class="govuk-body">Training providers may ask to see them later if you do not include them in your application.</p>
       </div>
 
       {{ govukButton({text: "Add another qualification", href: applicationPath + "/other-qualifications/add", classes: "govuk-button--secondary"}) }}

--- a/app/views/application/other-qualifications/type.njk
+++ b/app/views/application/other-qualifications/type.njk
@@ -1,0 +1,112 @@
+{% extends "_form-question.njk" %}
+
+{% set applicationPath = "/application/" + applicationId %}
+{% set international = applicationValue(["candidate", "otherNationality1"]) %}
+{% set title = "What type of qualification is it?" %}
+{% set itemName = "other qualifications" if international else "A levels and other qualifications" %}
+{% set allowsFeedback = true %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+      href: "/application/" + applicationId + "/other-qualifications/review"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  {% set otherUkConditionalHtml %}
+    <div class="govuk-form-group">
+      <label class="govuk-label govuk-label--s" for="otherQualifications-{{ id }}-typeUk">Qualification name</label>
+      <div id="type-uk-autocomplete-container"></div>
+    </div>
+  {% endset %}
+
+  {% set nonUkConditionalHtml %}
+    {{ govukInput({
+      label: {
+        text: "Qualification name",
+        classes: "govuk-label--s"
+      },
+      hint: {
+        html: "For example, High school diploma, Higher Secondary School Certificate, <span lang=\"fr\">Baccalauréat Général</span>, <span lang=\"es\">Título de Bachiller</span>"
+      }
+    } | decorateApplicationAttributes(["otherQualifications", id, "typeNonUk"])) }}
+  {% endset %}
+
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "What type of qualification is it?",
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
+      attributes: {
+        "data-module": "clear-hidden"
+      }
+    },
+    items: [{
+      value: "A level",
+      text: "A level"
+    }, {
+      value: "AS level",
+      text: "AS level"
+    }, {
+      value: "GCSE",
+      text: "GCSE"
+    }, {
+      value: "Other UK qualification",
+      text: "Another UK qualification",
+      conditional: {
+        html: otherUkConditionalHtml
+      }
+    }, {
+      value: "Non-UK qualification",
+      text: "A non-UK qualification",
+      conditional: {
+        html: nonUkConditionalHtml
+      }
+    }]
+  } | decorateApplicationAttributes(["otherQualifications", id, "type"])) }}
+
+  {{ govukInput({
+    value: "Yes",
+    type: "hidden"
+  } | decorateApplicationAttributes(["otherQualificationsDisclose"])) }}
+
+  {% set internationalConditionalHtml %}
+    {{ appAutocomplete({
+      label: {
+        text: "In which country is your institution based?"
+      },
+      items: countries
+    } | decorateApplicationAttributes(["otherQualifications", id, "country"])) }}
+  {% endset %}
+
+  {{ govukButton({
+    text: "Continue"
+  }) }}
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/public/javascripts/autocomplete.min.js"></script>
+  <script>
+    accessibleAutocomplete({
+      element: document.querySelector('#type-uk-autocomplete-container'),
+      id: 'otherQualifications-{{ id }}-typeUk',
+      name: "applications[{{ applicationId }}][otherQualifications][{{ id }}][typeUk]",
+      defaultValue: '{{ applicationValue(["otherQualifications", id, "typeUk"]) }}',
+      minLength: 2,
+      placeholder: false,
+      showNoOptionsFound: false,
+      source: [
+        'BTEC',
+        'O level',
+        'NVQ',
+        'Scottish National 5',
+        'Scottish Higher',
+        'Scottish Advanced Higher',
+        'SVQ',
+        'VRQ'
+      ]
+    })
+  </script>
+{% endblock %}

--- a/app/views/application/other-qualifications/type.njk
+++ b/app/views/application/other-qualifications/type.njk
@@ -60,7 +60,7 @@
       }
     }, {
       value: "Non-UK qualification",
-      text: "A non-UK qualification",
+      text: "A qualification not from the UK",
       conditional: {
         html: nonUkConditionalHtml
       }

--- a/app/views/application/other-qualifications/type.njk
+++ b/app/views/application/other-qualifications/type.njk
@@ -2,7 +2,7 @@
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set international = applicationValue(["candidate", "otherNationality1"]) %}
-{% set title = "What type of qualification is it?" %}
+{% set title = "What type of qualification do you want to add?" %}
 {% set itemName = "other qualifications" if international else "A levels and other qualifications" %}
 {% set allowsFeedback = true %}
 
@@ -35,7 +35,7 @@
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "What type of qualification is it?",
+        text: "What type of qualification do you want to add?",
         classes: "govuk-label--l",
         isPageHeading: true
       },

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -29,12 +29,12 @@
 {% endblock %}
 
 {% block primary %}
+  {% set showIncomplete = true %}
   <section class="app-section">
     <h2 class="govuk-heading-m govuk-!-font-size-27">{{ "Course" if applicationValue(["apply2"]) else "Courses" }}</h2>
     {% if not closed %}
       {% set choices = applicationValue(["choices"]) | toArray %}
       {% set showChoiceStatus = false %}
-      {% set showIncomplete = true %}
       {% include "_includes/review/choices.njk" %}
     {% else %}
       <p>You can apply for courses from 13 October.</p>


### PR DESCRIPTION
This simplifies the "A levels and other qualifications" flow so that the "What type of qualification do you want to add?" no longer contains an "I do not want to add any A levels and other qualifications" answer, in order to reduce the complexity of the question, and to more easily represent the candidate’s answers on the application review and within Manage.

Instead, candidates are routed through the review page, which contains the guidance about why it is a good idea to add A levels and other qualifications. This also means that this content is still visible even after adding the first qualification, to remind candidates that they can continue to add other qualifications.

Additionally, on the details screen, the font size of the labels has been reduced, and the "Do you want to add another qualification?" question has been dropped (although this could be restored).

➡️ [Trello card](https://trello.com/c/ugz3MWoX/4095-help-candidates-enter-other-qualifications-or-not-more-easily)

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/30665/140337319-231d063d-93bd-4fd1-be25-59f356e60f46.png)

![before-2](https://user-images.githubusercontent.com/30665/140337370-7089cfca-fb8a-46e5-b2e5-4147f1344116.png)

### After

![screenshot-localhost_3001-2021 11 15-10_44_00](https://user-images.githubusercontent.com/30665/141768444-6038c1a7-ba92-4442-8286-d95cdc5222a1.png)

![screenshot-localhost_3001-2021 11 15-10_44_30](https://user-images.githubusercontent.com/30665/141768461-7966e980-9547-4327-8ce2-8b77a07d6176.png)

![after-3](https://user-images.githubusercontent.com/30665/140337494-f179e277-d21c-46cf-b9dd-aeab672d93ba.png)

![screenshot-localhost_3001-2021 11 15-10_57_34](https://user-images.githubusercontent.com/30665/141770252-3870d537-d8a6-4ef2-a89d-e98c513665c9.png)

