### PR TITLE
Prevent application submission where only Foundation level degrees have been entered

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -24,6 +24,24 @@ const applicationWithDegreeSectionNotStarted = JSON.parse(JSON.stringify(require
 applicationWithDegreeSectionNotStarted.completed.degree = null
 applicationWithDegreeSectionNotStarted.degree = {}
 
+const applicationWithFoundationDegreeOnly = JSON.parse(JSON.stringify(require('./application')))
+applicationWithFoundationDegreeOnly.completed.degree = null
+applicationWithFoundationDegreeOnly.degree = {
+  abcde: {
+    id: 'abcde',
+    provenance: 'domestic',
+    type: 'Foundation of Arts',
+    level: 'Foundation',
+    subject: 'Art History',
+    org: 'The University of Edinburgh',
+    country: 'United Kingdom',
+    yearStart: '2006',
+    yearEnd: '2009',
+    completed: 'Yes',
+    grade: 'Lower second-class honours (2:2)'
+  }
+}
+
 module.exports = {
   applications: {
     12345: require('./application'),
@@ -35,6 +53,7 @@ module.exports = {
     GLOBE: require('./application-international'),
     WORLD: require('./application-international-with-choices'),
     DEGREE: applicationWithDegreeSectionNotStarted,
+    FOUNDATION: applicationWithFoundationDegreeOnly,
     21234: internationalApplicationNoRightToStudyYet,
     52614: applicationWhereNotMeetingMinimiumDegreeRequirement,
     21235: applicationWhereStudyingForGcse,

--- a/app/routes/application/degree.js
+++ b/app/routes/application/degree.js
@@ -146,7 +146,16 @@ module.exports = router => {
   // Render degree review page
   // Note: Must be defined before next route declaration
   router.get('/application/:applicationId/degree/review', (req, res) => {
+    const { applicationId } = req.params
+
+    const application = utils.applicationData(req)
+    const degrees = utils.toArray(application.degree)
+
+    // Needs to have at least 1 degree which is not a Foundation degree
+    const meetsMinimumDegreeCriteria = (degrees.length > 0 && !(degrees.every(degree => degree.level == "Foundation")))
+
     res.render('application/degree/review', {
+      meetsMinimumDegreeCriteria
     })
   })
 

--- a/app/views/application/degree/review.html
+++ b/app/views/application/degree/review.html
@@ -18,40 +18,56 @@
 
 {% block primary %}
 
+  {% set addDegreeButton %}
+    {{ govukButton({
+      text: ("Add another degree" if degreeCount > 0 else "Add degree"),
+      classes: ("govuk-button--secondary" if (meetsMinimumDegreeCriteria) else ""),
+      href: applicationPath + "/degree/add"
+    }) }}
+  {% endset %}
+
   {% if degreeCount == 0 %}
     <p class="govuk-body">You need an undergraduate degree to be eligible for teacher training.</p>
     <p class="govuk-body">You can also add any other degrees you have.</p>
+    {{ addDegreeButton | safe }}
+  {% elif not meetsMinimumDegreeCriteria %}
+    <p class="govuk-body">You need an undergraduate degree to be eligible for teacher training.</p>
+    {{ addDegreeButton | safe }}
+  {% else %}
+    {{ addDegreeButton | safe }}
   {% endif %}
 
-  {{ govukButton({
-    text: ("Add another degree" if degreeCount > 0 else "Add degree"),
-    classes: ("govuk-button--secondary" if degreeCount > 0 else ""),
-    href: applicationPath + "/degree/add"
-  }) }}
+
 
   {% if degreeCount > 0 %}
 
     {% include "_includes/review/degrees.html" %}
 
-    {{ govukRadios({
-      fieldset: {
-        classes: "govuk-!-width-two-thirds",
-        legend: {
-          text: "Have you completed this section?",
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [{
-        value: "true",
-        text: "Yes, I’ve completed this section"
-      }, {
-        value: "false",
-        text: "No, I’ll come back to it later"
-      }]
-    } | decorateApplicationAttributes(["completed", "degree"])) }}
+    {% if meetsMinimumDegreeCriteria %}
+      {{ govukRadios({
+        fieldset: {
+          classes: "govuk-!-width-two-thirds",
+          legend: {
+            text: "Have you completed this section?",
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [{
+          value: "true",
+          text: "Yes, I’ve completed this section"
+        }, {
+          value: "false",
+          text: "No, I’ll come back to it later"
+        }]
+      } | decorateApplicationAttributes(["completed", "degree"])) }}
 
-    {{ govukButton({
-      text: "Continue"
-    }) }}
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    {% endif %}
+
+
+
   {% endif %}
 {% endblock %}

--- a/app/views/application/degree/review.html
+++ b/app/views/application/degree/review.html
@@ -26,12 +26,10 @@
     }) }}
   {% endset %}
 
-  {% if degreeCount == 0 %}
-    <p class="govuk-body">You need an undergraduate degree to be eligible for teacher training.</p>
-    <p class="govuk-body">You can also add any other degrees you have.</p>
-    {{ addDegreeButton | safe }}
-  {% elif not meetsMinimumDegreeCriteria %}
-    <p class="govuk-body">You need an undergraduate degree to be eligible for teacher training.</p>
+  {% if degreeCount == 0 or not meetsMinimumDegreeCriteria  %}
+    <p class="govuk-body">You need a Bachelor degree or equivalent to start teacher training.</p>
+    <p class="govuk-body">Add your Bachelor degree even if you have not got your grade yet.</p>
+    <p class="govuk-body">You can also add any other degrees that you have, or you’re working towards.</p>
     {{ addDegreeButton | safe }}
   {% else %}
     {{ addDegreeButton | safe }}

--- a/app/views/application/degree/review.html
+++ b/app/views/application/degree/review.html
@@ -27,8 +27,8 @@
   {% endset %}
 
   {% if degreeCount == 0 or not meetsMinimumDegreeCriteria  %}
-    <p class="govuk-body">You need a Bachelor degree or equivalent to start teacher training.</p>
-    <p class="govuk-body">Add your Bachelor degree even if you have not got your grade yet.</p>
+    <p class="govuk-body">You need a bachelor’s degree or equivalent to start teacher training.</p>
+    <p class="govuk-body">Add your bachelor’s degree even if you have not got your grade yet.</p>
     <p class="govuk-body">You can also add any other degrees that you have, or you’re working towards.</p>
     {{ addDegreeButton | safe }}
   {% else %}


### PR DESCRIPTION
This updates the prototype to prevent candidates from marking the degree section as complete if they've only added Foundation degrees.

To do this, the "Have you completed this section?" question is removed from the bottom, and the "Add another degree" buttons switches to the primary green colour (rather than secondary grey). The guidance is also shown.

## Screenshot

![screenshot-localhost_3000-2021 11 29-15_37_47](https://user-images.githubusercontent.com/30665/143897483-110dd4d9-93ae-43f7-9f01-13d041c7d708.png)


