### PR TITLE
Add note on full terms and conditions, and being able to withdraw

### DIFF
--- a/app/views/_includes/item/offer.html
+++ b/app/views/_includes/item/offer.html
@@ -4,6 +4,7 @@
     <li>Disclosure and Barring Service check</li>
   </ul>
   <p>Contact the provider to find out more about these conditions.</p>
+  <p>You should also have received full terms and conditions from the provider.</p>
 {% endset %}
 
 {{ govukSummaryList({

--- a/app/views/application/decision/view.html
+++ b/app/views/application/decision/view.html
@@ -18,7 +18,7 @@
     {% if numberOfOffersReceived > 1 %}
       <li>your other {{ "offer" if numberOfOffersReceived == 2 else "offers"}} will be automatically declined</li>
     {% endif %}
-    <li>you will be able to cancel and withdraw at any time up until the course has started</li>
+    <li>you will be able to withdraw at any time up until the course has started</li>
   </ul>
 
   <p class="govuk-body">If you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year.</p>

--- a/app/views/application/decision/view.html
+++ b/app/views/application/decision/view.html
@@ -12,14 +12,17 @@
 {% block primary %}
   {% include "_includes/item/offer.html" %}
 
-  <p class="govuk-body">Before you accept:</p>
+  <p class="govuk-body">If you accept this offer:</p>
 
   <ul class="govuk-list govuk-list--bullet">
     {% if numberOfOffersReceived > 1 %}
-      <li>if you accept this offer, your other {{ "offer" if numberOfOffersReceived == 2 else "offers"}} will be automatically declined</li>
+      <li>your other {{ "offer" if numberOfOffersReceived == 2 else "offers"}} will be automatically declined</li>
     {% endif %}
-    <li>if you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year</li>
+    <li>you will be able to cancel and withdraw at any time up until the course has started</li>
   </ul>
+
+  <p class="govuk-body">If you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year.</p>
+
 
   <p class="govuk-body">If you need help, you can speak to our <a href="https://beta-adviser-getintoteaching.education.gov.uk" class="govuk-link">teacher training advisers</a>.</p>
 


### PR DESCRIPTION
This explores how we might make it clearer to candidates that accepting an offer means accepting the full terms and conditions from the provider (which they should have received off-service) and that they can cancel/withdraw after they accept (which they have the right to do under consumer regulation).

Feedback on the content welcome.

## Before

<img width="840" alt="Screenshot 2021-12-03 at 15 36 27" src="https://user-images.githubusercontent.com/30665/144629863-3d7744e3-aa30-4459-aedf-846da3d07dd9.png">

## After

<img width="969" alt="Screenshot 2021-12-03 at 15 35 43" src="https://user-images.githubusercontent.com/30665/144629895-c2a72f1c-6d93-408a-ac2a-57ed05032cea.png">

