### PR TITLE
Link to terms and conditions

### DIFF
--- a/app/views/_includes/item/offer.html
+++ b/app/views/_includes/item/offer.html
@@ -4,7 +4,7 @@
     <li>Disclosure and Barring Service check</li>
   </ul>
   <p>Contact the provider to find out more about these conditions.</p>
-  <p>You should also have received full terms and conditions from the provider.</p>
+  <p><a href="#" class="govuk-link">View full terms and conditions</a></p>
 {% endset %}
 
 {{ govukSummaryList({

--- a/app/views/_includes/item/offer.html
+++ b/app/views/_includes/item/offer.html
@@ -4,6 +4,7 @@
     <li>Disclosure and Barring Service check</li>
   </ul>
   <p>Contact the provider to find out more about these conditions.</p>
+  <p>You should also have received full terms and conditions from the provider.</p>
 {% endset %}
 
 {{ govukSummaryList({

--- a/app/views/application/decision/view.html
+++ b/app/views/application/decision/view.html
@@ -12,14 +12,17 @@
 {% block primary %}
   {% include "_includes/item/offer.html" %}
 
-  <p class="govuk-body">Before you accept:</p>
+  <p class="govuk-body">If you accept this offer:</p>
 
   <ul class="govuk-list govuk-list--bullet">
     {% if numberOfOffersReceived > 1 %}
-      <li>if you accept this offer, your other {{ "offer" if numberOfOffersReceived == 2 else "offers"}} will be automatically declined</li>
+      <li>your other {{ "offer" if numberOfOffersReceived == 2 else "offers"}} will be automatically declined</li>
     {% endif %}
-    <li>if you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year</li>
+    <li>you will be able to cancel and withdraw at any time up until the course has started</li>
   </ul>
+
+  <p class="govuk-body">If you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year.</p>
+
 
   <p class="govuk-body">If you need help, you can speak to our <a href="https://beta-adviser-getintoteaching.education.gov.uk" class="govuk-link">teacher training advisers</a>.</p>
 


### PR DESCRIPTION
This builds about #604 but adds a link to the full terms and conditions from the provider.  To do this, we’d need to collect those conditions from providers (as a link or uploaded document) via Publish, so this would be a longer-term project.

## Screenshot

<img width="829" alt="Screenshot 2021-12-03 at 15 42 46" src="https://user-images.githubusercontent.com/30665/144630786-767bfd32-5eb8-419c-8b30-ec4f4968d177.png">


