### PR TITLE
Bugfix: remove references to req.flash

### DIFF
--- a/app/routes/application/references.js
+++ b/app/routes/application/references.js
@@ -92,7 +92,6 @@ module.exports = router => {
           date: now.toISOString()
         })
 
-        req.flash('success', `Reference request cancelled for ${application.references[id].name}`)
       }
 
       if (action === 'deactivate') {
@@ -113,8 +112,6 @@ module.exports = router => {
           note: 'Reminder sent',
           date: now.toISOString()
         })
-
-        req.flash('success', `Reminder sent to ${application.references[id].name}`)
       }
 
       if (action === 'retry') {
@@ -122,8 +119,6 @@ module.exports = router => {
           note: `Request sent to ${application.references[id].email}`,
           date: now.toISOString()
         })
-
-        req.flash('success', `Reference request sent to ${application.references[id].email}`)
       }
 
       res.redirect(referrer)
@@ -163,7 +158,6 @@ module.exports = router => {
         date: now.toISOString()
       })
 
-      req.flash('success', `Reference request sent to ${application.references[id].name}`)
       res.redirect(`/application/${applicationId}/references/review`)
     } else {
       res.redirect(`/application/${applicationId}/references/${id}/candidate`)

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -5,9 +5,7 @@ module.exports = router => {
     const application = utils.applicationData(req)
     const { applicationId } = req.params
     const pageObject = {}
-    const successFlash = req.flash('success')
-
-    if (successFlash[0] === 'submitted-incompleted-application') {
+    if (req.query.showErrors === 'true') {
       pageObject.errorList = []
       const sections = {
         choices: application.apply2 ? 'Course choice not marked as completed' : 'Course choices not marked as completed',
@@ -81,8 +79,7 @@ module.exports = router => {
     if (completedApplication) {
       res.redirect(`/application/${applicationId}/equality-monitoring`)
     } else {
-      req.flash('success', 'submitted-incompleted-application')
-      res.redirect(`/application/${applicationId}/review`)
+      res.redirect(`/application/${applicationId}/review?showErrors=true`)
     }
   })
 }


### PR DESCRIPTION
This no longer works, for some reason.

Refactoring so that error messages on review page use a query string instead.

Reference flash messages will have to be refactored later.