### PR TITLE
Exploration of showing training adviser within the application

### DIFF
--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -4,7 +4,7 @@ const utils = require('./../../utils')
 module.exports = router => {
   router.get('/dashboard/:applicationId/:applicationStatus?', (req, res) => {
     const { applicationId, applicationStatus } = req.params
-    const { confirmation } = req.query
+    const { confirmation, gotAdviser } = req.query
 
     if (applicationStatus) {
       // clear data and reset it from file
@@ -460,7 +460,8 @@ module.exports = router => {
       endedWithoutSuccess,
       numberOfApplicationsWithdrawn,
       numberOfChoicesAwaitingDecision,
-      confirmation
+      confirmation,
+      gotAdviser
     })
   })
 }

--- a/app/routes/application/gcse.js
+++ b/app/routes/application/gcse.js
@@ -131,9 +131,11 @@ module.exports = router => {
   // Render equivalency page
   router.get('/application/:applicationId/gcse/:id/equivalency', (req, res) => {
     const { id } = req.params
+    const { gotAdviser } = req.query
 
     res.render('application/gcse/equivalency', {
-      id
+      id,
+      gotAdviser
     })
   })
 

--- a/app/routes/application/personal-statement.js
+++ b/app/routes/application/personal-statement.js
@@ -1,9 +1,23 @@
 module.exports = router => {
-  router.get('/application/:applicationId/personal-statement/:view', (req, res) => {
+
+  // Edit
+  router.get('/application/:applicationId/personal-statement', (req, res) => {
+    const { applicationId, view } = req.params
+    const { referrer, gotAdviser } = req.query
+
+    res.render(`application/personal-statement/index`, {
+      formaction: referrer || `/application/${applicationId}`,
+      referrer,
+      gotAdviser
+    })
+  })
+
+  // Review
+  router.get('/application/:applicationId/personal-statement/review', (req, res) => {
     const { applicationId, view } = req.params
     const { referrer } = req.query
 
-    res.render(`application/personal-statement/${view}`, {
+    res.render(`application/personal-statement/review`, {
       formaction: referrer || `/application/${applicationId}`,
       referrer
     })

--- a/app/views/application/gcse/equivalency.html
+++ b/app/views/application/gcse/equivalency.html
@@ -15,12 +15,12 @@
 {% block primary %}
   <p class="govuk-body">You can still apply for teacher training if you do not have a qualification which demonstrates this.</p>
 
-  <p class="govuk-body">Some providers may let you sit an equivalency test to show you have the required skills.</p>
+  <p class="govuk-body">Some providers may let you do an equivalency test to show you have the required skills.</p>
 
   {% if gotAdviser %}
-    <p class="govuk-body">Contact your chosen provider or your adviser Bob for advice: <br><a href="#" class="govuk-link">bob.jones@ta-recruit.education.gov.uk</a></p>
+    <p class="govuk-body">Contact your training provider or your adviser Bob at <br><a href="#" class="govuk-link">bob.jones@ta-recruit.education.gov.uk</a>for advice.</p>
   {% else %}
-    <p class="govuk-body">For advice, contact your chosen training provider or <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">get a teacher training adviser</a>.</p>
+    <p class="govuk-body">Contact your training provider or <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">get a teacher training adviser</a> for advice.</p>
   {% endif %}
 
   {{ govukCharacterCount({

--- a/app/views/application/gcse/equivalency.html
+++ b/app/views/application/gcse/equivalency.html
@@ -17,7 +17,11 @@
 
   <p class="govuk-body">Some providers may let you sit an equivalency test to show you have the required skills.</p>
 
-  <p class="govuk-body">For advice, contact your chosen training provider or a <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">teacher training adviser</a>.</p>
+  {% if gotAdviser %}
+    <p class="govuk-body">Contact your chosen provider or your adviser Bob for advice: <br><a href="#" class="govuk-link">bob.jones@ta-recruit.education.gov.uk</a></p>
+  {% else %}
+    <p class="govuk-body">For advice, contact your chosen training provider or a <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">teacher training adviser</a>.</p>
+  {% endif %}
 
   {{ govukCharacterCount({
     label: {

--- a/app/views/application/gcse/equivalency.html
+++ b/app/views/application/gcse/equivalency.html
@@ -20,7 +20,7 @@
   {% if gotAdviser %}
     <p class="govuk-body">Contact your chosen provider or your adviser Bob for advice: <br><a href="#" class="govuk-link">bob.jones@ta-recruit.education.gov.uk</a></p>
   {% else %}
-    <p class="govuk-body">For advice, contact your chosen training provider or a <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">teacher training adviser</a>.</p>
+    <p class="govuk-body">For advice, contact your chosen training provider or <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">get a teacher training adviser</a>.</p>
   {% endif %}
 
   {{ govukCharacterCount({

--- a/app/views/application/personal-statement/index.html
+++ b/app/views/application/personal-statement/index.html
@@ -20,7 +20,11 @@
 {% block primary %}
 
   {% set getAdviserHtml %}
-    <p class="govuk-body"><a href="https://adviser-getintoteaching.education.gov.uk/" class="govuk-link">Find out if you’re eligible for a teacher training adviser</a> to get advice on your application from an experienced teacher.</p>
+    {% if gotAdviser %}
+      <p class="govuk-body">Speak to your adviser Bob for support in answering this question: <br><a href="#" class="govuk-link">bob.jones@ta-recrit.education.gov.uk</a>
+    {% else %}
+      <p class="govuk-body"><a href="https://adviser-getintoteaching.education.gov.uk/" class="govuk-link">Find out if you’re eligible for a teacher training adviser</a> to get advice on your application from an experienced teacher.</p>
+    {% endif %}
   {% endset %}
 
   {% set guidanceHtml %}

--- a/app/views/application/personal-statement/index.html
+++ b/app/views/application/personal-statement/index.html
@@ -21,9 +21,9 @@
 
   {% set getAdviserHtml %}
     {% if gotAdviser %}
-      <p class="govuk-body">Speak to your adviser Bob for support in answering this question: <br><a href="#" class="govuk-link">bob.jones@ta-recrit.education.gov.uk</a>
+      <p class="govuk-body">Contact your teacher training adviser Bob at <br><a href="#" class="govuk-link">bob.jones@ta-recrit.education.gov.uk</a> for advice on answering this question.</p>
     {% else %}
-      <p class="govuk-body"><a href="https://adviser-getintoteaching.education.gov.uk/" class="govuk-link">Get a teacher training adviser</a> to get advice on answering this question from an experienced teacher.</p>
+      <p class="govuk-body"><a href="https://adviser-getintoteaching.education.gov.uk/" class="govuk-link">Get a teacher training adviser</a> for advice on answering this question.</p>
     {% endif %}
   {% endset %}
 

--- a/app/views/application/personal-statement/index.html
+++ b/app/views/application/personal-statement/index.html
@@ -23,7 +23,7 @@
     {% if gotAdviser %}
       <p class="govuk-body">Speak to your adviser Bob for support in answering this question: <br><a href="#" class="govuk-link">bob.jones@ta-recrit.education.gov.uk</a>
     {% else %}
-      <p class="govuk-body"><a href="https://adviser-getintoteaching.education.gov.uk/" class="govuk-link">Find out if you’re eligible for a teacher training adviser</a> to get advice on your application from an experienced teacher.</p>
+      <p class="govuk-body"><a href="https://adviser-getintoteaching.education.gov.uk/" class="govuk-link">Get a teacher training adviser</a> to get advice on answering this question from an experienced teacher.</p>
     {% endif %}
   {% endset %}
 

--- a/app/views/dashboard/_apply-again.html
+++ b/app/views/dashboard/_apply-again.html
@@ -11,7 +11,13 @@
 
   <p class="govuk-body">If now’s the right time, you can still apply for courses that start this academic year.</p>
 
-  <p class="govuk-body">To talk about your options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
+  <p class="govuk-body">
+    {% if gotAdviser %}
+      You can talk about your options with your adviser Bob: <br><a href="#">bob.jones@ta-recruit.education.gov.uk</a>.
+    {% else %}
+      To talk about your options, <a href="https://beta-adviser-getintoteaching.education.gov.uk/">get a teacher training adviser</a>.
+    {% endif %}
+  </p>
 
   {{ govukButton({
     text: "Apply again",

--- a/app/views/dashboard/_apply-again.html
+++ b/app/views/dashboard/_apply-again.html
@@ -9,13 +9,13 @@
     {% endif %}
   </h2>
 
-  <p class="govuk-body">If now’s the right time, you can still apply for courses that start this academic year.</p>
+  <p class="govuk-body">If now’s the right time for you, you can still apply for courses that start this academic year.</p>
 
   <p class="govuk-body">
     {% if gotAdviser %}
-      You can talk about your options with your adviser Bob: <br><a href="#">bob.jones@ta-recruit.education.gov.uk</a>.
+      Contact your teacher training adviser Bob at <br><a href="#">bob.jones@ta-recruit.education.gov.uk</a> to talk about your options.
     {% else %}
-      To talk about your options, <a href="https://beta-adviser-getintoteaching.education.gov.uk/">get a teacher training adviser</a>.
+      <a href="https://beta-adviser-getintoteaching.education.gov.uk/">Get a teacher training adviser</a> to talk about your options.
     {% endif %}
   </p>
 


### PR DESCRIPTION
Currently we link to the "Get an adviser" service at several points within the application and after submission, as we know that teacher training advisers are often able to help support candidates with some of the stumbling blocks within the process.

However, we don’t currently know whether the candidate already has a teacher training adviser assigned. This means that the text is often vague to cover both scenarios, for example "speak to a teacher training adviser" – but the link still goes to the Get an adviser service, which is less helpful if the candidate already has one.

If we could tell wither the candidate had an adviser, we could:

* make the call to action to **get an adviser** stronger, if we know they don't have one
* remind candidates of the name and email address of their adviser, if they have one

Below is an exploration of how this might work in 3 of the places we currently link to the Get an adviser service.

🗂️ [Trello card](https://trello.com/c/D0uiSI4l/3996-consider-how-the-guidance-in-apply-could-change-if-we-know-whether-or-not-the-candidate-has-a-teacher-training-adviser)

## Personal statement

### Current

<img width="710" alt="Screenshot 2021-12-10 at 15 19 15" src="https://user-images.githubusercontent.com/30665/145597796-4846ff7d-7df4-4d46-9106-304b676557ed.png">

### Future: with no adviser
 
<img width="698" alt="Screenshot 2021-12-10 at 15 20 44" src="https://user-images.githubusercontent.com/30665/145597819-b5823ac6-fd1a-49cc-9f2c-91dfc944fa20.png">

### Future: with an adviser

<img width="706" alt="Screenshot 2021-12-10 at 15 21 42" src="https://user-images.githubusercontent.com/30665/145597878-6f8384af-83b3-4b97-a0ca-c5a4c167346c.png">

## GCSE equivalencies

### Current

<img width="700" alt="Screenshot 2021-12-10 at 15 22 48" src="https://user-images.githubusercontent.com/30665/145598053-3da8bf6e-1325-4e33-9ed8-804ee303403d.png">

### Future: with no adviser

<img width="666" alt="Screenshot 2021-12-10 at 15 24 26" src="https://user-images.githubusercontent.com/30665/145598304-d3cfd37d-ee90-42cc-a385-f3cb218476e0.png">

### Future: with an adviser

<img width="691" alt="Screenshot 2021-12-10 at 15 24 52" src="https://user-images.githubusercontent.com/30665/145598355-f9e0f0d5-6578-448f-8e0e-2b352643f62d.png">

## Unsuccessful with an application

### Current

<img width="702" alt="Screenshot 2021-12-10 at 15 25 35" src="https://user-images.githubusercontent.com/30665/145598479-a77dcaf9-8d11-4ef8-a808-20152c99b381.png">

### Future: with no adviser

<img width="733" alt="Screenshot 2021-12-10 at 15 26 11" src="https://user-images.githubusercontent.com/30665/145598575-59470cc1-4d21-4ec6-8f76-d76aa9a6ad3d.png">

### Future: with an adviser

<img width="732" alt="Screenshot 2021-12-10 at 15 26 35" src="https://user-images.githubusercontent.com/30665/145598647-0ee80d62-f071-4ba4-8694-8fb94fca8079.png">

