### PR TITLE
Use node 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "supertest": "^6.1.6"
       },
       "engines": {
-        "node": ">=12.0.0 <17.0.0"
+        "node": "16.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "12.0.3",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <17.0.0"
+    "node": "16.x"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
This aims to prevent a Heroku deploy message saying:

```
- Dangerous semver range (>) in engines.node
         https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
```

It should also reduce any errors caused by developers using different versions of node locally.