### PR TITLE
Change "Request a reference" button colour and text

### DIFF
--- a/app/views/dashboard/_course-choices.html
+++ b/app/views/dashboard/_course-choices.html
@@ -169,9 +169,9 @@
     {% endfor %}
 
     {{ govukButton({
-      text: "Request a reference",
+      text: "Request another reference",
       href: "/dashboard/" + applicationId + "/references/add?referrer=" + referrer,
-      classes: "xgovuk-button--secondary"
+      classes: "govuk-button--secondary"
     }) }}
 
 


### PR DESCRIPTION
Changes the "Request a reference" button to secondary grey colour with the text "Request another reference", as it now doesn't need to be so prominent at this point as they've already requested at least 2.

## Before

<img width="711" alt="Screenshot 2022-08-03 at 17 11 41" src="https://user-images.githubusercontent.com/30665/182657603-8b83f0bd-01d0-4f3d-bfdc-9e47808c63cd.png">

## After

<img width="680" alt="Screenshot 2022-08-03 at 17 11 31" src="https://user-images.githubusercontent.com/30665/182657630-7b1456d4-163a-4bda-be62-1cd73674581d.png">

