### PR TITLE
Update referee flow

### DIFF
--- a/app/routes/reference.js
+++ b/app/routes/reference.js
@@ -4,8 +4,7 @@
 module.exports = router => {
   router.get('/reference', (req, res) => {
     res.render('reference/index', {
-      referrer: req.query.referrer,
-      type: req.query.type
+      referrer: req.query.referrer
     })
   })
 

--- a/app/views/admin/index.html
+++ b/app/views/admin/index.html
@@ -9,6 +9,6 @@
     <li><a href="/admin/flags">View feature flags</a></li>
     <li><a href="/admin/send-email">Send email</a></li>
     <li><a href="/admin/states">Mock application states</a></li>
-    <li><a href="/reference">Giving a reference flow</a></li>
+    <li><a href="/reference/start">Giving a reference flow</a></li>
   </ul>
 {% endblock %}

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -2,7 +2,7 @@
 
 {% set formaction = referrer or "/reference/review" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Additional information about " + candidate_name %}
+{% set title = "Reference for " + candidate_name %}
 {% set hasAccountLinks = false %}
 
 {% block pageNavigation %}
@@ -19,16 +19,14 @@
 
 {% block primary %}
 
-  <p class="govuk-body">Give additional information, such as:</p>
+  <p class="govuk-body">Do not give opinions about {{ candidate_name }}. Your reference should be based on facts such as:</p>
 
   {% if type == 'character' %}
 
-    <p class="govuk-body">Give additional information, such as details of:</p>
-
     <ul class="govuk-list govuk-list--bullet">
-      <li>volunteering they have done with you</li>
+      <li>volunteering they’ve done with you</li>
       <li>mentoring you’ve done for them</li>
-      <li>activities you have done together</li>
+      <li>activities you’ve done together</li>
     </ul>
 
   {% elif type == 'professional' %}
@@ -36,26 +34,23 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>the dates they worked with you</li>
       <li>their role and responsibilities</li>
-      <li>the reason they left their role</li>
     </ul>
 
   {% else %}
 
     <ul class="govuk-list govuk-list--bullet">
       <li>their academic performance</li>
-      <li>their predicted grade, if they have not yet completed their course</li>
+      <li>their predicted grade, if they have not completed their course</li>
     </ul>
 
   {% endif %}
-
-  <p class="govuk-body">{{candidate_name }} will not be able to see what you write about them.</p>
 
   {{ govukCharacterCount({
     id: "reference-comments",
     name: "reference[comments]",
     value: data.reference.comments,
     label: {
-      text: "Additional information",
+      text: "Reference",
       classes: "govuk-label--m govuk-!-margin-top-6"
     },
     maxwords: 500,

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -2,7 +2,7 @@
 
 {% set formaction = referrer or "/reference/review" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Does " + candidate_name + " have the potential to teach?" %}
+{% set title = "Your reference for " + candidate_name %}
 {% set hasAccountLinks = false %}
 
 {% block pageNavigation %}
@@ -19,30 +19,26 @@
 
 {% block primary %}
 
+  <p class="govuk-body">You can include further factual information, such as:</p>
 
-    <p class="govuk-body">You could comment on things like their:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>communication skills</li>
-      <li>reliability and professionalism</li>
-      <li>transferable skills</li>
-      <li>ability to work with children</li>
-      <li>academic skills</li>
-    </ul>
-
-    <p class="govuk-body">You can write up to 500 words. </p>
-    <p class="govuk-body">If you need more time, save and return later using the link in your email.</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the dates they were employed by you</li>
+    <li>their role and responsibilities</li>
+    <li>predicted grades, if they have not yet completed their course</li>
+    <li>[...]</li>
+  </ul>
 
   {{ govukCharacterCount({
     id: "reference-comments",
     name: "reference[comments]",
     value: data.reference.comments,
     label: {
-      text: "Your reference",
+      text: "Further information (optional)",
       classes: "govuk-label--m govuk-!-margin-top-6"
     },
     maxwords: 500,
-    rows: 15
+    threshold: 95,
+    rows: 6
   }) }}
 
   {{ govukButton({

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -19,9 +19,11 @@
 
 {% block primary %}
 
+  <p class="govuk-body">Give additional information, such as:</p>
+
   {% if type == 'character' %}
 
-    <p class="govuk-body">You can give additional information, such as details of:</p>
+    <p class="govuk-body">Give additional information, such as details of:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>volunteering they have done with you</li>
@@ -31,26 +33,29 @@
 
   {% elif type == 'professional' %}
 
-    <p class="govuk-body">You can give additional information, such as:</p>
-
     <ul class="govuk-list govuk-list--bullet">
       <li>the dates they worked with you</li>
       <li>their role and responsibilities</li>
+      <li>the reason they left their role</li>
     </ul>
 
   {% else %}
 
-
-    <p class="govuk-body">You can give additional information, such as their predicted grade if they have not yet completed their course.</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>their academic performance</li>
+      <li>their predicted grade, if they have not yet completed their course</li>
+    </ul>
 
   {% endif %}
+
+  <p class="govuk-body">{{candidate_name }} will not be able to see what you write about them.</p>
 
   {{ govukCharacterCount({
     id: "reference-comments",
     name: "reference[comments]",
     value: data.reference.comments,
     label: {
-      text: "Additional information (optional)",
+      text: "Additional information",
       classes: "govuk-label--m govuk-!-margin-top-6"
     },
     maxwords: 500,
@@ -59,7 +64,7 @@
   }) }}
 
   {{ govukButton({
-    text: "Save"
+    text: "Save and continue"
   }) }}
 
   <p class="govuk-body">

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -21,6 +21,7 @@
 
   <p class="govuk-body">Do not give opinions about {{ candidate_name }}. Your reference should be based on facts such as:</p>
 
+  {% set type = data['referee_type'] %}
   {% if type == 'character' %}
 
     <ul class="govuk-list govuk-list--bullet">
@@ -29,7 +30,7 @@
       <li>activities you’ve done together</li>
     </ul>
 
-  {% elif type == 'professional' %}
+  {% elif type == 'professional' or type == 'school' %}
 
     <ul class="govuk-list govuk-list--bullet">
       <li>the dates they worked with you</li>
@@ -61,11 +62,5 @@
   {{ govukButton({
     text: "Save and continue"
   }) }}
-
-  <p class="govuk-body">
-    <a href="/reference/comments?referrer=/reference/review&type=academic">academic</a> |
-    <a href="/reference/comments?referrer=/reference/review&type=professional">professional or school based</a> |
-    <a href="/reference/comments?referrer=/reference/review&type=character">character</a>
-  </p>
 
 {% endblock %}

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -19,14 +19,31 @@
 
 {% block primary %}
 
-  <p class="govuk-body">You can give additional information, such as:</p>
+  {% if type == 'character' %}
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>the dates they worked with you</li>
-    <li>their role and responsibilities</li>
-    <li>predicted grades, if they have not yet completed their course</li>
-    <li>[...]</li>
-  </ul>
+    <p class="govuk-body">You can give additional information, such as details of:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>volunteering they have done with you</li>
+      <li>mentoring you’ve done for them</li>
+      <li>activities you have done together</li>
+    </ul>
+
+  {% elif type == 'professional' %}
+
+    <p class="govuk-body">You can give additional information, such as:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the dates they worked with you</li>
+      <li>their role and responsibilities</li>
+    </ul>
+
+  {% else %}
+
+
+    <p class="govuk-body">You can give additional information, such as their predicted grade if they have not yet completed their course.</p>
+
+  {% endif %}
 
   {{ govukCharacterCount({
     id: "reference-comments",
@@ -44,4 +61,11 @@
   {{ govukButton({
     text: "Save"
   }) }}
+
+  <p class="govuk-body">
+    <a href="/reference/comments?referrer=/reference/review&type=academic">academic</a> |
+    <a href="/reference/comments?referrer=/reference/review&type=professional">professional or school based</a> |
+    <a href="/reference/comments?referrer=/reference/review&type=character">character</a>
+  </p>
+
 {% endblock %}

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -2,7 +2,7 @@
 
 {% set formaction = referrer or "/reference/review" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Your reference for " + candidate_name %}
+{% set title = "Additional information about " + candidate_name %}
 {% set hasAccountLinks = false %}
 
 {% block pageNavigation %}
@@ -19,10 +19,10 @@
 
 {% block primary %}
 
-  <p class="govuk-body">You can include further factual information, such as:</p>
+  <p class="govuk-body">You can give additional information, such as:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>the dates they were employed by you</li>
+    <li>the dates they worked with you</li>
     <li>their role and responsibilities</li>
     <li>predicted grades, if they have not yet completed their course</li>
     <li>[...]</li>
@@ -33,7 +33,7 @@
     name: "reference[comments]",
     value: data.reference.comments,
     label: {
-      text: "Further information (optional)",
+      text: "Additional information (optional)",
       classes: "govuk-label--m govuk-!-margin-top-6"
     },
     maxwords: 500,

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -19,7 +19,7 @@
 
 {% block primary %}
 
-  <p class="govuk-body">Do not give opinions about {{ candidate_name }}. Your reference should be based on facts such as:</p>
+  <p class="govuk-body">West Lancashire SCITT  will use your reference to check the details in Jane Doe’s application. You could include information such as:</p>
 
   {% set type = data['referee_type'] %}
   {% if type == 'character' %}

--- a/app/views/reference/confirmation.html
+++ b/app/views/reference/confirmation.html
@@ -36,7 +36,7 @@
       {% endset %}
 
       {{ govukRadios({
-        classes: "govuk-radios--inline",
+        classes: "",
         fieldset: {
           legend: {
             text: "Please rate your experience of giving a reference",
@@ -55,7 +55,7 @@
       }) }}
 
       {{ govukRadios({
-        classes: "govuk-radios--inline",
+        classes: "",
         fieldset: {
           legend: {
             text: "Please rate how useful our guidance was",

--- a/app/views/reference/decline.html
+++ b/app/views/reference/decline.html
@@ -2,7 +2,7 @@
 
 {% set formaction = "/reference/decline/answer" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Are you sure you are unable to give " + candidate_name + " a reference?" %}
+{% set title = "Are you sure you’re unable to give " + candidate_name + " a reference?" %}
 {% set hasAccountLinks = false %}
 
 {% block pageNavigation %}
@@ -17,7 +17,7 @@
       <h1 class="govuk-heading-l">{{ title }}</h1>
       <form action="/reference/thank-you">
         {{ govukButton({
-          text: "Yes, I am unable to give a reference"
+          text: "Yes, I’m unable to give a reference"
         }) }}
       </form>
     </div>

--- a/app/views/reference/email-request.html
+++ b/app/views/reference/email-request.html
@@ -7,18 +7,20 @@
   <p class="govuk-body">Jane Doe has accepted an offer from West Lancashire SCITT for a place on a teacher training course. </p>
   <p class="govuk-body">They’ve said that you can give them a reference. Their place on the course can only be confirmed after West Lancashire SCITT has received their references.</p>
 
+  <p class="govuk-body">If you give a reference you’ll need to say: </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>how you know Jane Doe and how long you’ve known them for</li>
+    <li>whether you have any concerns about Jane Doe working with children</li>
+  </ul>
+
+
   <p class="govuk-body">Use this link to give the reference as soon as you can:</p>
 
   <p class="govuk-body"><a href="/reference">http://localhost:3000/reference?token=onNYS8Uvzs2nicqd5htb</a></p>
 
   <p class="govuk-body">You can also use the link to say that you cannot give a reference, so that Jane Doe knows to ask someone else.</p>
 
-  <p class="govuk-body">If you give a reference you’ll need to say: </p>
-
-  <ul class="govuk-list govuk-list--bullet">
-    <li>how you know Jane Doe and how long you’ve known them for</li>
-    <li>whether you know of any reason why they should not train to be a teacher</li>
-  </ul>
-
   <p class="govuk-body">Your reference will not be sent to Jane Doe.</p>
+
 {% endblock %}

--- a/app/views/reference/email-request.html
+++ b/app/views/reference/email-request.html
@@ -1,22 +1,24 @@
 {% extends "_email.html" %}
 
-{% set title = "Give a reference to support the teacher training application of Jane Doe" %}
+{% set title = "Teacher training reference needed for Jane Doe" %}
 
 {% block content %}
   <p class="govuk-body">Dear Debroah Lueilwitz,</p>
-  <p class="govuk-body">Jane Doe put us in touch with you to get a reference for their teacher training application.</p>
-  <p class="govuk-body">They have applied to the following courses:</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>Mallowpond TAFE – Business</li>
-    <li>Mallowpond Technical College – Biomedical Science</li>
-    <li>Falconholt Technical College – Forensic Science</li>
-  </ul>
-  <p class="govuk-body">Please use the link below to give a reference as soon as possible.</p>
-  <p class="govuk-body"><a href="/reference">http://localhost:3000/reference?token=onNYS8Uvzs2nicqd5htb</a></p>
-  <p class="govuk-body">If you won’t give Jane Doe a reference, please let us know by clicking the link below.</p>
-  <p class="govuk-body"><a href="/reference/decline">http://localhost:3000/reference/refuse-feedback?token=onNYS8Uvzs2nicqd5htb</a></p>
+  <p class="govuk-body">Jane Doe has accepted an offer from University College London for a place on a teacher training course. </p>
+  <p class="govuk-body">They’ve said that you can give them a reference. Their place on the course can only be confirmed after University College London has received their references.</p>
 
-  <h2 class="govuk-heading-m">Your data</h2>
-  <p class="govuk-body">We’ll only use your data to process the candidate’s application, unless you agree to be contacted about your experience of giving a reference.</p>
-  <p class="govuk-body">We’ll ask about this before you submit any information.</p>
+  <p class="govuk-body">Use this link to give the reference as soon as you can:</p>
+
+  <p class="govuk-body"><a href="/reference">http://localhost:3000/reference?token=onNYS8Uvzs2nicqd5htb</a></p>
+
+  <p class="govuk-body">You can also use the link to say that you cannot give a reference, so that Jane Doe knows to ask someone else.</p>
+
+  <p class="govuk-body">If you give a reference you’ll need to say: </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>how you know Jane Doe and how long you’ve known them for</li>
+    <li>whether you know of any reason why they should not train to be a teacher</li>
+  </ul>
+
+  <p class="govuk-body">Your reference will not be sent to Jane Doe.</p>
 {% endblock %}

--- a/app/views/reference/email-request.html
+++ b/app/views/reference/email-request.html
@@ -4,8 +4,8 @@
 
 {% block content %}
   <p class="govuk-body">Dear Debroah Lueilwitz,</p>
-  <p class="govuk-body">Jane Doe has accepted an offer from University College London for a place on a teacher training course. </p>
-  <p class="govuk-body">They’ve said that you can give them a reference. Their place on the course can only be confirmed after University College London has received their references.</p>
+  <p class="govuk-body">Jane Doe has accepted an offer from West Lancashire SCITT for a place on a teacher training course. </p>
+  <p class="govuk-body">They’ve said that you can give them a reference. Their place on the course can only be confirmed after West Lancashire SCITT has received their references.</p>
 
   <p class="govuk-body">Use this link to give the reference as soon as you can:</p>
 

--- a/app/views/reference/index.html
+++ b/app/views/reference/index.html
@@ -2,6 +2,7 @@
 
 {% set formaction = "/reference/answer" %}
 {% set candidate_name = "Jane Doe" %}
+{% set provider_name = "West Lancashire SCITT" %}
 {% set title = "A reference for " + candidate_name + "" %}
 {% set hasAccountLinks = false %}
 
@@ -15,15 +16,11 @@
 
 {% block primary %}
 
-  <h1 class="govuk-heading-l">Reference for {{ candidate_name }}</h1>
+  <h1 class="govuk-heading-l">Give a reference for {{ candidate_name }}</h1>
 
-  <p class="govuk-body">To give a reference you’ll need to:</p>
+  <p class="govuk-body">{{ candidate_name }} has accepted an offer for a place on a teacher training course.</p>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>confirm how you know {{ candidate_name }}</li>
-    <li>say whether you know of any reason why they should not train to be a teacher</li>
-    <li>give any additional information</li>
-  </ul>
+  <p class="govuk-body">Your reference will only be sent to {{ provider_name }}. It will not be sent to {{ candidate_name }}.</p>
 
   {{ govukRadios({
     fieldset: {

--- a/app/views/reference/index.html
+++ b/app/views/reference/index.html
@@ -18,9 +18,9 @@
 
   <h1 class="govuk-heading-l">Give a reference for {{ candidate_name }}</h1>
 
-  <p class="govuk-body">{{ candidate_name }} has accepted an offer for a place on a teacher training course.</p>
+  <p class="govuk-body">{{ candidate_name }} has accepted an offer from {{ provider_name }} for a place on a teacher training course. They’ve said that you can give them a reference.</p>
 
-  <p class="govuk-body">Your reference will only be sent to {{ provider_name }}. It will not be sent to {{ candidate_name }}.</p>
+  <p class="govuk-body">Your reference will not be sent to {{ candidate_name }}.</p>
 
   {{ govukRadios({
     fieldset: {

--- a/app/views/reference/index.html
+++ b/app/views/reference/index.html
@@ -15,12 +15,22 @@
 
 {% block primary %}
 
+  <h1 class="govuk-heading-l">Reference for {{ candidate_name }}</h1>
+
+  <p class="govuk-body">To give a reference you’ll need to:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>confirm how you know {{ candidate_name }}</li>
+    <li>say whether you know of any reason why they should not train to be a teacher</li>
+    <li>give any additional information</li>
+  </ul>
+
   {{ govukRadios({
     fieldset: {
       legend: {
         text: "Can you give a reference for " + candidate_name + "?",
-        classes: "govuk-fieldset__legend--l",
-        isPageHeading: true
+        classes: "govuk-fieldset__legend--s",
+        isPageHeading: false
       }
     },
     idPrefix: "reference-answer",

--- a/app/views/reference/relationship.html
+++ b/app/views/reference/relationship.html
@@ -44,7 +44,7 @@
       name: "reference[relationship][correction]",
       value: data.reference.relationship.correction,
       label: {
-        text: "Say how you know " + candidate_name + " and how long you’ve known them"
+        text: "How you know " + candidate_name + " and how long you’ve known them"
       },
       maxwords: 50,
       rows: 5

--- a/app/views/reference/relationship.html
+++ b/app/views/reference/relationship.html
@@ -17,10 +17,24 @@
   {% endif %}
 {% endblock %}
 
+{% set type = data['referee_type'] %}
+{% set relationship %}
+  {% if type == 'character' %}
+    She is my mentor. I’ve known her for 4 years.
+  {% elif type == 'school' %}
+    She is the headteacher at the school I work at. I’ve known her for 2 years.
+  {% elif type == 'professional' %}
+    She was my supervisor at work. I’ve known her for 3 years.
+  {% else %}
+    She was my course supervisor at university. I’ve known her for a year.
+  {% endif %}
+{% endset %}
+
+
 {% block primary %}
   <p class="govuk-body govuk-!-margin-bottom-2">{{ candidate_name }} has described how you know them:</p>
   {{ govukInsetText({
-    text: "He was my course supervisor at university. I’ve known him for a year.",
+    text: relationship,
     classes: " govuk-!-margin-top-0"
   }) }}
 

--- a/app/views/reference/relationship.html
+++ b/app/views/reference/relationship.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body govuk-!-margin-bottom-2">{{ candidate_name }} has described how they know you:</p>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ candidate_name }} has described how you know them:</p>
   {{ govukInsetText({
     text: "He was my course supervisor at university. I’ve known him for a year.",
     classes: " govuk-!-margin-top-0"
@@ -30,7 +30,7 @@
       name: "reference[relationship][correction]",
       value: data.reference.relationship.correction,
       label: {
-        text: "Tell us what your relationship is to " + candidate_name + " and how long you’ve known them"
+        text: "Say how you know " + candidate_name + " and how long you’ve known them"
       },
       maxwords: 50,
       rows: 5

--- a/app/views/reference/relationship.html
+++ b/app/views/reference/relationship.html
@@ -18,9 +18,10 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">{{ candidate_name }} describes how they know you as follows:</p>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ candidate_name }} has described how they know you:</p>
   {{ govukInsetText({
-    text: "He was my course supervisor at university. I’ve known him for a year."
+    text: "He was my course supervisor at university. I’ve known him for a year.",
+    classes: " govuk-!-margin-top-0"
   }) }}
 
   {% set correctRelationshipHtml %}

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -53,7 +53,7 @@
       }
     }, {
       key: {
-        text: "Further information (optional)"
+        text: "Additional information (optional)"
       },
       value: {
         html: (data.reference.comments or "Not entered")

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -11,21 +11,19 @@
       You confirmed their description of how you know them.
     {% endset %}
   {% else %}
-    {% set relationshipValue = "You amended this to: " + data.reference.relationship.correction %}
+    {% set relationshipValue = "You said this is how you know them: <br><br>" + data.reference.relationship.correction %}
   {% endif %}
 
   {% if data.reference.safeguarding.concern == "Yes" %}
     {% set safeguardingValue = data.reference.safeguarding.reason %}
   {% else %}
-    {% set safeguardingValue = data.reference.safeguarding.concern %}
+    {% set safeguardingValue = "You have no concerns." %}
   {% endif %}
-
-  <p class="govuk-body">If you're not ready to submit yet, you can return using the link in your email.</p>
 
   {{ govukSummaryList({
     rows: [{
       key: {
-        text: "Confirm how you know " + candidate_name | safe
+        text: "How you know them"
       },
       value: {
         text: relationshipValue | safe
@@ -39,7 +37,7 @@
       }
     }, {
       key: {
-        text: "Do you have concerns about " + candidate_name + " working with children?" | safe
+        text: "Concerns about them  working with children" | safe
       },
       value: {
         text: safeguardingValue

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -8,10 +8,10 @@
 {% block primary %}
   {% if data.reference.relationship.correct == "Yes" %}
     {% set relationshipValue %}
-      You confirmed this as correct.
+      You confirmed their description of how you know them.
     {% endset %}
   {% else %}
-    {% set relationshipValue = "Amended to: " + data.reference.relationship.correction %}
+    {% set relationshipValue = "You amended this to: " + data.reference.relationship.correction %}
   {% endif %}
 
   {% if data.reference.safeguarding.concern == "Yes" %}
@@ -25,7 +25,7 @@
   {{ govukSummaryList({
     rows: [{
       key: {
-        text: "Relationship"
+        text: "Confirm how you know " + candidate_name | safe
       },
       value: {
         text: relationshipValue | safe
@@ -39,7 +39,7 @@
       }
     }, {
       key: {
-        text: "Concerns about candidate working with children"
+        text: "Do you have concerns about " + candidate_name + " working with children?" | safe
       },
       value: {
         text: safeguardingValue
@@ -53,7 +53,7 @@
       }
     }, {
       key: {
-        text: "Additional information"
+        text: "Reference"
       },
       value: {
         html: (data.reference.comments or "Not entered")

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -7,9 +7,11 @@
 
 {% block primary %}
   {% if data.reference.relationship.correct == "Yes" %}
-    {% set relationshipValue = "Confirmed by referee" %}
+    {% set relationshipValue %}
+      You confirmed this as correct.
+    {% endset %}
   {% else %}
-    {% set relationshipValue = "Amended by referee to: " + data.reference.relationship.correction %}
+    {% set relationshipValue = "Amended to: " + data.reference.relationship.correction %}
   {% endif %}
 
   {% if data.reference.safeguarding.concern == "Yes" %}
@@ -26,11 +28,11 @@
         text: "Relationship"
       },
       value: {
-        text: relationshipValue
+        text: relationshipValue | safe
       },
       actions: {
         items: [{
-          href: "/reference?referrer=/reference/review",
+          href: "/reference/relationship?referrer=/reference/review",
           text: "Change",
           visuallyHiddenText: "relationship to candidate"
         }]
@@ -51,10 +53,10 @@
       }
     }, {
       key: {
-        text: "Reference"
+        text: "Further information (optional)"
       },
       value: {
-        html: data.reference.comments
+        html: (data.reference.comments or "Not entered")
       },
       actions: {
         items: [{

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -53,7 +53,7 @@
       }
     }, {
       key: {
-        text: "Additional information (optional)"
+        text: "Additional information"
       },
       value: {
         html: (data.reference.comments or "Not entered")

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -2,7 +2,7 @@
 
 {% set formaction = "/reference/confirmation" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Your reference for " + candidate_name %}
+{% set title = "Check your reference for " + candidate_name %}
 {% set hasAccountLinks = false %}
 
 {% block primary %}

--- a/app/views/reference/safeguarding.html
+++ b/app/views/reference/safeguarding.html
@@ -2,7 +2,7 @@
 
 {% set formaction = referrer or "/reference/comments" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Do you know of any reason why " + candidate_name + " should not work with children?" %}
+{% set title = "Do you have any concerns about " + candidate_name + " working with children?" %}
 {% set hasAccountLinks = false %}
 
 {% block pageNavigation %}
@@ -24,9 +24,13 @@
       name: "reference[safeguarding][reason]",
       value: data.reference.safeguarding.reason,
       label: {
-        text: "Tell us why you think " + candidate_name + " should not work with children"
+        text: "My concerns about " + candidate_name + " working with children"
       },
-      maxwords: 150,
+      hint: {
+        text: "Include any substantiated allegations. Provide facts, not opinions."
+      },
+      maxwords: 200,
+      threshold: 95,
       rows: 5
     }) }}
   {% endset %}
@@ -35,16 +39,16 @@
     idPrefix: "reference-safeguarding-concern",
     name: "reference[safeguarding][concern]",
     items: [{
-      value: "No",
-      text: "No",
-      checked: checked("reference.safeguarding.concern", "No")
-    }, {
       value: "Yes",
-      text: "Yes",
+      text: "Yes, I have a concern",
       checked: checked("reference.safeguarding.concern", "Yes"),
       conditional: {
         html: safeguardingConcernHtml
       }
+    },{
+      value: "No",
+      text: "No",
+      checked: checked("reference.safeguarding.concern", "No")
     }]
   }) }}
 

--- a/app/views/reference/safeguarding.html
+++ b/app/views/reference/safeguarding.html
@@ -27,7 +27,7 @@
         text: "My concerns about " + candidate_name + " working with children"
       },
       hint: {
-        text: "Include any substantiated allegations. Provide facts, not opinions."
+        text: "Give facts, not your opinion."
       },
       maxwords: 200,
       threshold: 95,
@@ -40,7 +40,7 @@
     name: "reference[safeguarding][concern]",
     items: [{
       value: "Yes",
-      text: "Yes, I have a concern",
+      text: "Yes, I have concerns",
       checked: checked("reference.safeguarding.concern", "Yes"),
       conditional: {
         html: safeguardingConcernHtml

--- a/app/views/reference/start.html
+++ b/app/views/reference/start.html
@@ -1,0 +1,15 @@
+{% extends "_content.html" %}
+
+{% block primary %}
+
+<h1 class="govuk-heading-l">References</h1>
+
+<ul class="govuk-list">
+  <li><a href="/reference/email-request?referee_type=academic" class="govuk-link">Academic</li>
+  <li><a href="/reference/email-request?referee_type=school" class="govuk-link">School based</li>
+  <li><a href="/reference/email-request?referee_type=professional" class="govuk-link">Company</li>
+  <li><a href="/reference/email-request?referee_type=character" class="govuk-link">Other</li>
+</ul>
+
+
+{% endblock %}


### PR DESCRIPTION
This updates the referee flow, now that references are given after an offer has been accepted rather than before an application has been submitted.

Given that references are now purely for safeguarding purposes rather than to assess candidates, the reference can now be focused on providing shorter, factual information.

The examples in the bulleted list vary depending on the reference type (academic, professional, school-based or character).

The rest of the flow has been updated slightly too, following a review.

🗂️ [Trello card](https://trello.com/c/v8ZUInA0/561-revised-reference-interface-for-referees)