### PR TITLE
Use referee name in summary card titles instead of 'First reference' etc

### DIFF
--- a/app/views/_includes/item/reference.html
+++ b/app/views/_includes/item/reference.html
@@ -1,13 +1,4 @@
-{% set titleText %}
-  {% if loop.index0 == 0 %}
-    First
-  {% elif loop.index0 == 1 %}
-    Second
-  {% elif loop.index0 == 2 %}
-    Third
-  {% endif %}
-  reference
-{% endset %}
+{% set titleText = item.name %}
 
 {% if item.status == 'Reference received' %}
   {% set referenceStatusHtml %}


### PR DESCRIPTION
This switches the title in the summary card on the references review pages to use the name of the referee instead of "First reference", "Second reference" etc.

This is because:

* the names might be easier to scan
* the order isn't important at all, but using "first", "second" etc might falsly imply that it is
* ordinal numbers can be slow to read, particularly when getting up to higher numbers ("Eleventh", "Sixteenth") – although it's unlikely many candidates add more than 10
* Using "reference" might imply that the reference has been collected (or will be), but in the new flow, the person isn't contacted for a reference until later.

There should always be a name, as the reference isn't saved to the database until after a name has been added.

One possible downside is that the name is now shown twice, which may be confusing.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/30665/188429465-0c49378e-077d-46fa-baad-f77951c9efb6.png)

### After

![after](https://user-images.githubusercontent.com/30665/188429490-84b57ded-3896-43e5-a78d-bdcd925583ce.png)
