### PR TITLE
Remove suggestion that expected degree grades should be confirmed by academic referees

### DIFF
--- a/app/views/application/degree/grade.html
+++ b/app/views/application/degree/grade.html
@@ -40,9 +40,6 @@
             label: {
               text: gradeLabel
             },
-            hint: {
-              text: "Your expected grade should be confirmed by an academic referee."
-            } if not completed,
             classes: "govuk-input--width-20"
           } | decorateApplicationAttributes(["degree", id, "grade"])) }}
         {% endset %}
@@ -86,9 +83,6 @@
                 classes: "govuk-fieldset__legend--l"
               }
             },
-            hint: {
-              text: "Your expected grade should be confirmed by an academic referee."
-            } if not completed and not international,
             items: [{
               value: "First-class honours",
               text: "First-class honours"

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -40,8 +40,8 @@
   {% else %}
 
     <ul class="govuk-list govuk-list--bullet">
+      <li>the dates of their courses</li>
       <li>their academic performance</li>
-      <li>their predicted grade, if they have not completed their course</li>
     </ul>
 
   {% endif %}

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -40,7 +40,7 @@
   {% else %}
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>the dates of their courses</li>
+      <li>when their course started and ended</li>
       <li>their academic performance</li>
     </ul>
 


### PR DESCRIPTION
We don't think (backed up by some research) that most universities give students "predicted grades", and we don't think most academic referees would be able to confirm these.

### Screenshots

| Before | After |
|----|----|
| ![degree-before](https://user-images.githubusercontent.com/30665/190420045-661b0556-1a41-49c6-9020-8b5eb8e5e89d.png) |  ![grade-after](https://user-images.githubusercontent.com/30665/190420058-70f5085a-a34f-447f-a182-3d4ba75b7e6e.png) |
| ![reference-before](https://user-images.githubusercontent.com/30665/190420092-e5856dde-06ff-4471-909d-37424f64f590.png) | ![reference-after](https://user-images.githubusercontent.com/30665/190454110-00941a39-71f7-4d73-803d-2230c1c73c7d.png) |

