### PR TITLE
Update ethnicity questions

### DIFF
--- a/app/views/application/equality-monitoring/ethnic-background.html
+++ b/app/views/application/equality-monitoring/ethnic-background.html
@@ -1,7 +1,9 @@
 {% extends "_form.html" %}
 {% set parent = "Equality and diversity questions" %}
 {% if applicationValue(["equality-monitoring", "ethnic-group"]) == "Another ethnic group" %}
-  {% set title = "Which of the following best describes your ethnicity?" %}
+  {% set title = "Which of the following best describes your background?" %}
+{% elif applicationValue(["equality-monitoring", "ethnic-group"]) == "Mixed or multiple ethnic groups" %}
+  {% set title = "Which of the following best describes your Mixed or Multiple ethnic groups background?" %}
 {% else %}
   {% set ethnicGroup = applicationValue(["equality-monitoring", "ethnic-group"]) %}
   {% set title = "Which of the following best describes your " + ethnicGroup + " background?" %}
@@ -14,47 +16,11 @@
 {% endblock %}
 
 {% block primary %}
-  {% set asianOtherHtml %}
+  {% set otherHtml %}
     {{ govukInput({
       classes: "govuk-!-width-two-thirds",
       label: {
-        text: "Your Asian background (optional)"
-      }
-    } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
-  {% endset -%}
-
-  {% set blackOtherHtml %}
-    {{ govukInput({
-      classes: "govuk-!-width-two-thirds",
-      label: {
-        text: "Your Black background (optional)"
-      }
-    } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
-  {% endset -%}
-
-  {% set mixedOtherHtml %}
-    {{ govukInput({
-      classes: "govuk-!-width-two-thirds",
-      label: {
-        text: "Your Mixed background (optional)"
-      }
-    } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
-  {% endset -%}
-
-  {% set whiteOtherHtml %}
-    {{ govukInput({
-      classes: "govuk-!-width-two-thirds",
-      label: {
-        text: "Your White background (optional)"
-      }
-    } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
-  {% endset -%}
-
-  {% set otherOtherHtml %}
-    {{ govukInput({
-      classes: "govuk-!-width-two-thirds",
-      label: {
-        text: "Describe your ethnic background (optional)"
+        text: "How would you describe your background? (optional)"
       }
     } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
   {% endset -%}
@@ -67,17 +33,19 @@
         }
       },
       items: [{
+        text: "Indian"
+      },
+      {
+        text: "Pakistani"
+      },
+      {
         text: "Bangladeshi"
       }, {
         text: "Chinese"
       }, {
-        text: "Indian"
-      }, {
-        text: "Pakistani"
-      }, {
-        text: "Another Asian background",
+        text: "Any other Asian background",
         conditional: {
-          html: asianOtherHtml
+          html: otherHtml
         }
       }, {
         divider: "or"
@@ -85,7 +53,7 @@
         text: "Prefer not to say"
       }]
     } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background"])) }}
-  {% elif ethnicGroup == "Black, African, Black British or Caribbean" %}
+  {% elif ethnicGroup == "Black, African, Caribbean or Black British" %}
     {{ govukRadios({
       fieldset: {
         attributes: {
@@ -97,9 +65,9 @@
       }, {
         text: "Caribbean"
       }, {
-        text: "Another Black background",
+        text: "Any other Black, African or Caribbean background",
         conditional: {
-          html: blackOtherHtml
+          html: otherHtml
         }
       }, {
         divider: "or"
@@ -115,15 +83,15 @@
         }
       },
       items: [{
-        text: "Asian and White"
+        text: "White and Black Caribbean"
       }, {
-        text: "Black African and White"
+        text: "White and Black African"
       }, {
-        text: "Black Caribbean and White"
+        text: "White and Asian"
       }, {
-        text: "Another Mixed background",
+        text: "Any other Mixed or Multiple ethnic background",
         conditional: {
-          html: mixedOtherHtml
+          html: otherHtml
         }
       }, {
         divider: "or"
@@ -139,15 +107,17 @@
         }
       },
       items: [{
-        text: "British, English, Northern Irish, Scottish, or Welsh"
+        text: "English, Welsh, Scottish, Northern Irish or British"
       }, {
         text: "Irish"
       }, {
-        text: "Irish Traveller or Gypsy"
+        text: "Gypsy or Irish Traveller"
       }, {
-        text: "Another White background",
+        text: "Roma"
+      }, {
+        text: "Any other White background",
         conditional: {
-          html: whiteOtherHtml
+          html: otherHtml
         }
       }, {
         divider: "or"
@@ -165,9 +135,9 @@
       items: [{
         text: "Arab"
       }, {
-        text: "Another ethnic background",
+        text: "Any other ethnic group",
         conditional: {
-          html: otherOtherHtml
+          html: otherHtml
         }
       }, {
         divider: "or"

--- a/app/views/application/equality-monitoring/ethnic-group.html
+++ b/app/views/application/equality-monitoring/ethnic-group.html
@@ -11,6 +11,22 @@
 {% block primary %}
   {{ govukRadios({
     items: [{
+      text: "White",
+      label: {
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Includes any White background"
+      }
+    },{
+      text: "Mixed or multiple ethnic groups",
+      label: {
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Includes any Mixed background"
+      }
+    },{
       text: "Asian or Asian British",
       label: {
         classes: "govuk-label--s"
@@ -19,28 +35,12 @@
         text: "Includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani"
       }
     }, {
-      text: "Black, African, Black British or Caribbean",
+      text: "Black, African, Caribbean or Black British",
       label: {
         classes: "govuk-label--s"
       },
       hint: {
         text: "Includes any Black background"
-      }
-    }, {
-      text: "Mixed or multiple ethnic groups",
-      label: {
-        classes: "govuk-label--s"
-      },
-      hint: {
-        text: "Includes any Mixed background"
-      }
-    }, {
-      text: "White",
-      label: {
-        classes: "govuk-label--s"
-      },
-      hint: {
-        text: "Includes any White background"
       }
     }, {
       text: "Another ethnic group",


### PR DESCRIPTION
This updates the ethnicity questions to bring them in line with the [GOV.UK Design System pattern for equality information](https://design-system.service.gov.uk/patterns/equality-information/) - with the exception that Roma has been added as an option, following the addition of that option to the 2021 census and the HESA ITT ethnic group categories.

The other changes are ordering changes, and changing "Another" to "Any other" and "Your Black background (optional)" to "How would you describe your background? (optional)".

## Screenshots

tbc