### PR TITLE
Referee flow amends

### DIFF
--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -19,7 +19,9 @@
 
 {% block primary %}
 
-  <p class="govuk-body">West Lancashire SCITT  will use your reference to check the details in Jane Doe’s application. You could include information such as:</p>
+  <p class="govuk-body">Your reference should contain factual information, not opinions.</p>
+
+  <p class="govuk-body">You could include:</p>
 
   {% set type = data['referee_type'] %}
   {% if type == 'character' %}
@@ -41,7 +43,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>when their course started and ended</li>
-      <li>their academic performance</li>
+      <li>their academic record</li>
     </ul>
 
   {% endif %}
@@ -55,7 +57,7 @@
       classes: "govuk-label--m govuk-!-margin-top-6"
     },
     maxwords: 500,
-    threshold: 95,
+    threshold: 50,
     rows: 6
   }) }}
 

--- a/app/views/reference/comments.html
+++ b/app/views/reference/comments.html
@@ -19,7 +19,7 @@
 
 {% block primary %}
 
-  <p class="govuk-body">Your reference should contain factual information, not opinions.</p>
+  <p class="govuk-body">Your reference should contain facts, not your opinions.</p>
 
   <p class="govuk-body">You could include:</p>
 
@@ -27,15 +27,14 @@
   {% if type == 'character' %}
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>volunteering they’ve done with you</li>
-      <li>mentoring you’ve done for them</li>
-      <li>activities you’ve done together</li>
+      <li>details of how you know Jane Doe</li>
+      <li>things they’ve done or you’ve done together</li>
     </ul>
 
   {% elif type == 'professional' or type == 'school' %}
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>the dates they worked with you</li>
+      <li>when they worked with you</li>
       <li>their role and responsibilities</li>
     </ul>
 

--- a/app/views/reference/email-request.html
+++ b/app/views/reference/email-request.html
@@ -4,29 +4,28 @@
 {% set type = data['referee_type'] %}
 
 {% block content %}
-  <p class="govuk-body">Dear Debroah Lueilwitz,</p>
+  <p class="govuk-body">Dear Debroah Lueilwitz</p>
   <p class="govuk-body">Jane Doe has accepted an offer from West Lancashire SCITT for a place on a teacher training course. </p>
-  <p class="govuk-body">They’ve said that you can give them a reference. Their place on the course can only be confirmed after West Lancashire SCITT has received their references.</p>
+  <p class="govuk-body">They’ve said that you can give them a reference. </p>
 
-  <p class="govuk-body">If you give a reference for Jane Doe you’ll need to: </p>
+  <p class="govuk-body">You’ll need to: </p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>confirm how you know them and how long you’ve known them for</li>
-    <li>whether you have any concerns about them working with children</li>
 
     {% if type == 'character' %}
 
-      <li>give information which can be used to check their application, for example about activities you’ve done together</li>
+      <li>give factual information which can be used to check their application, for example about activities you’ve done together</li>
 
     {% elif type == 'professional' or type == 'school' %}
 
-      <li>give information which can be used to check their application, for example about their role and responsibilities at work</li>
+      <li>give factual information which can be used to check their application, for example about their role and responsibilities at work</li>
 
     {% else %}
 
-      <li>give information which can be used to check their application, for example about their academic performance</li>
+      <li>give factual information which can be used to check their application, for example about their academic performance</li>
 
     {% endif %}
+    <li>say whether you have any concerns about them working with children</li>
 
   </ul>
 
@@ -35,8 +34,6 @@
 
   <p class="govuk-body"><a href="/reference">http://localhost:3000/reference?token=onNYS8Uvzs2nicqd5htb</a></p>
 
-  <p class="govuk-body">You can also use the link to say that you cannot give a reference, so that Jane Doe knows to ask someone else.</p>
-
-  <p class="govuk-body">Your reference will not be sent to Jane Doe.</p>
+  <p class="govuk-body">If you cannot give a reference, use the link to tell Jane Doe so they can ask someone else. You will then receive no further emails about this.</p>
 
 {% endblock %}

--- a/app/views/reference/email-request.html
+++ b/app/views/reference/email-request.html
@@ -11,6 +11,7 @@
   <p class="govuk-body">You’ll need to: </p>
 
   <ul class="govuk-list govuk-list--bullet">
+    <li>say whether you have any concerns about them working with children</li>
 
     {% if type == 'character' %}
 
@@ -25,15 +26,14 @@
       <li>give factual information which can be used to check their application, for example about their academic performance</li>
 
     {% endif %}
-    <li>say whether you have any concerns about them working with children</li>
 
   </ul>
 
 
-  <p class="govuk-body">Use this link to give the reference as soon as you can:</p>
+  <p class="govuk-body">Use this link to give the reference or to say you cannot give one:</p>
 
   <p class="govuk-body"><a href="/reference">http://localhost:3000/reference?token=onNYS8Uvzs2nicqd5htb</a></p>
 
-  <p class="govuk-body">If you cannot give a reference, use the link to tell Jane Doe so they can ask someone else. You will then receive no further emails about this.</p>
+  <p class="govuk-body">If you say you cannot give a reference, Jane Doe will know they should ask someone else. You will receive no further emails.</p>
 
 {% endblock %}

--- a/app/views/reference/index.html
+++ b/app/views/reference/index.html
@@ -38,7 +38,7 @@
       checked: (data["reference-answer"] == "Yes")
     }, {
       value: "No",
-      text: "No, I am unable to give a reference",
+      text: "No, I’m unable to give a reference",
       checked: (data["reference-answer"] == "No")
     }]
   }) }}

--- a/app/views/reference/relationship.html
+++ b/app/views/reference/relationship.html
@@ -2,7 +2,7 @@
 
 {% set formaction = referrer or "/reference/safeguarding" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Confirm how you know " + candidate_name %}
+{% set title = "Confirm how " + candidate_name + " knows you" %}
 {% set hasAccountLinks = false %}
 
 {% block pageNavigation %}
@@ -32,7 +32,7 @@
 
 
 {% block primary %}
-  <p class="govuk-body govuk-!-margin-bottom-2">{{ candidate_name }} has described how you know them:</p>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ candidate_name }} has described they know you:</p>
   {{ govukInsetText({
     text: relationship,
     classes: " govuk-!-margin-top-0"
@@ -54,7 +54,7 @@
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "Is this correct?",
+        text: "Is this accurate?",
         classes: "govuk-fieldset__legend--m"
       }
     },
@@ -66,7 +66,7 @@
       checked: checked("reference.relationship.correct", "Yes")
     }, {
       value: "No",
-      text: "No",
+      text: "No, I’d like to make a change",
       checked: checked("reference.relationship.correct", "No"),
       conditional: {
         html: correctRelationshipHtml

--- a/app/views/reference/relationship.html
+++ b/app/views/reference/relationship.html
@@ -32,7 +32,7 @@
 
 
 {% block primary %}
-  <p class="govuk-body govuk-!-margin-bottom-2">{{ candidate_name }} has described they know you:</p>
+  <p class="govuk-body govuk-!-margin-bottom-2">{{ candidate_name }} has described how they know you:</p>
   {{ govukInsetText({
     text: relationship,
     classes: " govuk-!-margin-top-0"
@@ -54,7 +54,7 @@
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "Is this accurate?",
+        text: "Is this description accurate?",
         classes: "govuk-fieldset__legend--m"
       }
     },
@@ -66,7 +66,7 @@
       checked: checked("reference.relationship.correct", "Yes")
     }, {
       value: "No",
-      text: "No, I’d like to make a change",
+      text: "No, I’d like to give a different description",
       checked: checked("reference.relationship.correct", "No"),
       conditional: {
         html: correctRelationshipHtml

--- a/app/views/reference/relationship.html
+++ b/app/views/reference/relationship.html
@@ -66,7 +66,7 @@
       checked: checked("reference.relationship.correct", "Yes")
     }, {
       value: "No",
-      text: "No, I’d like to give a different description",
+      text: "No, I’ll give a more accurate description",
       checked: checked("reference.relationship.correct", "No"),
       conditional: {
         html: correctRelationshipHtml

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -17,7 +17,7 @@
   {% if data.reference.safeguarding.concern == "Yes" %}
     {% set safeguardingValue = data.reference.safeguarding.reason %}
   {% else %}
-    {% set safeguardingValue = "You have no concerns." %}
+    {% set safeguardingValue = "You do not know of any reason why they should not work with children." %}
   {% endif %}
 
   {{ govukSummaryList({
@@ -37,7 +37,7 @@
       }
     }, {
       key: {
-        text: "Concerns about them  working with children" | safe
+        text: "Working with children" | safe
       },
       value: {
         text: safeguardingValue

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -6,12 +6,30 @@
 {% set hasAccountLinks = false %}
 
 {% block primary %}
+
+  {% set type = data['referee_type'] %}
+  {% set relationship %}
+    {% if type == 'character' %}
+      She is my mentor. I’ve known her for 4 years.
+    {% elif type == 'school' %}
+      She is the headteacher at the school I work at. I’ve known her for 2 years.
+    {% elif type == 'professional' %}
+      She was my supervisor at work. I’ve known her for 3 years.
+    {% else %}
+      She was my course supervisor at university. I’ve known her for a year.
+    {% endif %}
+  {% endset %}
+
+
   {% if data.reference.relationship.correct == "Yes" %}
     {% set relationshipValue %}
-      You confirmed their description of how you know them.
+      You confirmed their description of how they know you:<br><br>
+
+      {{ relationship }}
+
     {% endset %}
   {% else %}
-    {% set relationshipValue = "You said this is how you know them: <br><br>" + data.reference.relationship.correction %}
+    {% set relationshipValue = "You gave this description of how you know them: <br><br>" + data.reference.relationship.correction %}
   {% endif %}
 
   {% if data.reference.safeguarding.concern == "Yes" %}
@@ -20,10 +38,12 @@
     {% set safeguardingValue = "You do not know any reason why they should not work with children." %}
   {% endif %}
 
+
+
   {{ govukSummaryList({
     rows: [{
       key: {
-        text: "How you know them"
+        text: ("How they know you" if data.reference.relationship.correct == "Yes" else "How you know them")
       },
       value: {
         text: relationshipValue | safe

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -17,7 +17,7 @@
   {% if data.reference.safeguarding.concern == "Yes" %}
     {% set safeguardingValue = data.reference.safeguarding.reason %}
   {% else %}
-    {% set safeguardingValue = "You do not know of any reason why they should not work with children." %}
+    {% set safeguardingValue = "You do not know any reason why they should not work with children." %}
   {% endif %}
 
   {{ govukSummaryList({

--- a/app/views/reference/safeguarding.html
+++ b/app/views/reference/safeguarding.html
@@ -2,7 +2,7 @@
 
 {% set formaction = referrer or "/reference/comments" %}
 {% set candidate_name = "Jane Doe" %}
-{% set title = "Do you have any concerns about " + candidate_name + " working with children?" %}
+{% set title = "Do you know any reason why " + candidate_name + " should not work with children?" %}
 {% set hasAccountLinks = false %}
 
 {% block pageNavigation %}
@@ -24,7 +24,7 @@
       name: "reference[safeguarding][reason]",
       value: data.reference.safeguarding.reason,
       label: {
-        text: "My concerns about " + candidate_name + " working with children"
+        text: "Why " + candidate_name + " should not work with children"
       },
       hint: {
         text: "Give facts, not your opinion."
@@ -40,7 +40,7 @@
     name: "reference[safeguarding][concern]",
     items: [{
       value: "Yes",
-      text: "Yes, I have concerns",
+      text: "Yes, I know a reason why they should not work with children",
       checked: checked("reference.safeguarding.concern", "Yes"),
       conditional: {
         html: safeguardingConcernHtml


### PR DESCRIPTION
### Email

- We removed content to focus on the most important things. For example, we removed bullet about confirming how long the referee has known the candidate. The referee cannot prepare for this question as they don't know what the candidate has written.
- We mentioned in the lead in to the link that it can be used to say that a referee cannot give a reference. We want them to do that rather than do nothing, so that the candidate knows they need to ask someone else.
- We added content to tell referees that if they use the service to say they can't give a reference, they will no longer receive emails about it. 

![CleanShot 2022-10-06 at 15 45 26](https://user-images.githubusercontent.com/29047487/194344084-ddecb71b-2691-456f-b306-5fdb96f034a8.png)

### Give a reference

- Changed "I am" to "I'm" to fit the usual style for the service.

![CleanShot 2022-10-06 at 15 46 40](https://user-images.githubusercontent.com/29047487/194344385-6a68488b-223f-4fae-86ec-0f11c9d1b4d3.png)

### Confirm how the candidate knows you

- The heading has been changed from "Confirm how you know ((candidate))" to "Confirm how ((candidate)) knows you". This better reflects what candidates are asked.
- We've changed "Is this correct?" to "Is this description accurate?" This refers to the body text which mentions a description. And we think that saying something is not correct might seem like more of a criticism than saying it's inaccurate.
- We changed "No" to "No, I'll give a more accurate description". In research some participants were worried about choosing "No" in case it led to a negative reference without a chance to explain.
- We did not change the wording of the label of the field revealed when the referee says "No". It's more natural for the referee to say how they know the candidate, rather than the other way around.

![CleanShot 2022-10-06 at 15 47 37](https://user-images.githubusercontent.com/29047487/194344652-c8fff5b6-6c20-4aae-ba82-e37348cbdbc5.png)

### Safeguarding

- The heading has been changed back to "Do you know any reason why ((candidate)) should not work with children" Following the research, we felt that "do you have any concerns" sounded too much like it was asking for opinions.
- The wording of the "Yes" response and the field it reveals have similarly been changed.

![CleanShot 2022-10-06 at 15 49 36@2x](https://user-images.githubusercontent.com/29047487/194345136-538476fe-5bcc-4ab3-97ee-3b16ac07dccd.png)

### Reference

- We changed “factual information, not opinions” to “facts, not your opinions.” This matches the hint text for the safeguarding question.
- For work or school experience references, we've changed “the dates they worked with you” to “when they worked for you”. We don’t need exact dates and we'd already made this change for academic references.
- For character references we removed the examples, since they may not reflect the type of relationship which the referee has with the candidate. Instead we ask them to say more about how they know the candidate and say something about what the candidate has done.

![CleanShot 2022-10-06 at 15 50 59@2x](https://user-images.githubusercontent.com/29047487/194345460-2f0f1db9-d9bd-406a-93f0-435248ae07ba.png)

### Check answers

- We've added logic to display "How they know you" if the referee agrees with what the candidate said. If the referee disagreed, they were asked to say how they know the candidate so the wording changes to "How you know them".
- "Concerns about them working with children" is now "Working with children".
- If the candidate said "No" to the safeguarding question, we use this generic text: "You do not know any reason why they should not work with children."
 
![CleanShot 2022-10-06 at 15 51 14](https://user-images.githubusercontent.com/29047487/194345529-cad021e3-b453-42ac-9675-4422be132f5d.png)
