### PR TITLE
Show message if you can't apply to a course

### DIFF
--- a/app/data/application.js
+++ b/app/data/application.js
@@ -35,7 +35,9 @@ module.exports = {
       starts: '2021-09',
       status: 'Awaiting decision',
       degreeRequired: 'degree',
-      isSalaried: true
+      isSalaried: true,
+      openFrom: '2022-10-11',
+      full: false
     },
     FGHIJ: {
       courseCode: '38PN',
@@ -48,7 +50,9 @@ module.exports = {
       starts: '2021-09',
       status: 'Awaiting decision',
       degreeRequired: 'degree',
-      isSalaried: false
+      isSalaried: false,
+      openFrom: '2022-10-11',
+      full: false
     },
     ZYXWV: {
       courseCode: '3C2X',
@@ -61,7 +65,9 @@ module.exports = {
       starts: '2021-09',
       status: 'Awaiting decision',
       degreeRequired: 'third',
-      isSalaried: false
+      isSalaried: false,
+      openFrom: '2022-10-11',
+      full: false
     }
   },
   references: {

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -46,6 +46,14 @@ applicationWithReceivedReferences.references.first.status = 'Received by trainin
 applicationWithReceivedReferences.references.second.status = 'Received by training provider'
 applicationWithReceivedReferences.references.third.status = 'Requested'
 
+const dateToday = new Date()
+let dateInOneWeek = dateToday
+dateInOneWeek.setDate(dateInOneWeek.getDate() + 7)
+
+const applicationWithCourseNotOpenedYet = JSON.parse(JSON.stringify(require('./application')))
+applicationWithCourseNotOpenedYet.choices.ABCDE.openFrom = dateInOneWeek.toISOString()
+applicationWithCourseNotOpenedYet.choices.ZYXWV.full = true
+
 module.exports = {
   applications: {
     12345: require('./application'),
@@ -62,7 +70,8 @@ module.exports = {
     21234: internationalApplicationNoRightToStudyYet,
     52614: applicationWhereNotMeetingMinimiumDegreeRequirement,
     21235: applicationWhereStudyingForGcse,
-    21236: applicationWithNoGcse
+    21236: applicationWithNoGcse,
+    19415: applicationWithCourseNotOpenedYet
   },
   findUrl: 'https://www.find-postgraduate-teacher-training.service.gov.uk',
   flags: {

--- a/app/routes/application/choices.js
+++ b/app/routes/application/choices.js
@@ -192,6 +192,22 @@ module.exports = router => {
     }
   })
 
+  router.get('/application/:applicationId/choices/:id/delete', (req, res) => {
+    const { applicationId, id } = req.params
+    res.render('application/choices/delete', {
+      applicationId,
+      id
+    })
+  })
+
+  router.post('/application/:applicationId/choices/:id/delete', (req, res) => {
+    const { applicationId, id } = req.params
+    const application = utils.applicationData(req)
+
+    delete application.choices[id]
+    res.redirect(`/application/${applicationId}/choices`)
+  })
+
   router.all('/application/:applicationId/choices/:choiceId/:view', (req, res) => {
     res.render(`application/choices/${req.params.view}`, {
       paths: pickPaths(req),

--- a/app/routes/delete.js
+++ b/app/routes/delete.js
@@ -28,12 +28,6 @@ module.exports = router => {
     let parent
     let type
     switch (section) {
-      case 'choices': {
-        parent = item.type ? `${item.providerCode} ${item.courseCode}` : 'Course choices'
-        type = 'choice'
-        break
-      }
-
       case 'degree': {
         parent = item.type ? `${item.type} ${item.subject}` : 'Degrees'
         type = 'degree'

--- a/app/views/_includes/review/choices.html
+++ b/app/views/_includes/review/choices.html
@@ -31,6 +31,7 @@
       and (item.status != "Application withdrawn")
       and (item.status != "Conditions not met")
       and (item.status != nil)
+      and data.applications[applicationId].status != 'started'
     %}
 
     {% set courseSummaryCard %}

--- a/app/views/_includes/review/choices.html
+++ b/app/views/_includes/review/choices.html
@@ -61,19 +61,22 @@
       <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-padding-top-0 govuk-!-padding-bottom-0">
         <h2 class="govuk-heading-s app-inset-text__title">
           {% if dateCourseOpens > dateToday %}
-            Applications for this course do not open until {{ dateCourseOpens | date("DDD") }}
+            You’ll be able to apply for this course from {{ dateCourseOpens | date("DDD") }}
           {% else %}
-            You cannot apply to this course as it has no vacancies
+            You cannot apply to this course as there are no places left on it
           {% endif %}
         </h2>
 
-        <p class="govuk-body">
           {% if dateCourseOpens > dateToday %}
-            You can wait until applications open or change your course choice.
+            <p class="govuk-body">You need to either:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li class="govuk-body">wait until {{ dateCourseOpens | date("DDD") }} to submit your application</li>
+              <li class="govuk-body">delete or change this course choice</li>
+            </ul>
           {% else %}
-            Contact the training provider to discuss alternatives or change your course choice.
+            <p class="govuk-body">You need to either delete or change this course choice.</p>
+            <p class="govuk-body">{{ provider.name }} may be able to recommend an alternative course.</p>
           {% endif %}
-        </p>
 
         {{ courseSummaryCard | safe }}
       </div>

--- a/app/views/_includes/review/choices.html
+++ b/app/views/_includes/review/choices.html
@@ -33,25 +33,59 @@
       and (item.status != nil)
     %}
 
-    {{ appSummaryCard({
-      classes: "govuk-!-margin-bottom-6",
-      headingLevel: 3,
-      titleText: provider.name,
-      actions: {
-        items: [{
-          href: applicationPath + "/choices/" + item.id + "/delete?referrer=" + referrer,
-          text: "Delete choice"
-        } if canAmend, {
-          href: applicationPath + "/" + item.id + "/withdraw",
-          text: "Withdraw"
-        } if canWithdraw, {
-          href: applicationPath + "/" + item.id + "/view",
-          text: "View and respond to offer"
-        } if canRespond and not hasResponded]
-      } if canAmend or canWithdraw or canRespond,
-      html: courseHtml
-    }) }}
+    {% set courseSummaryCard %}
+      {{ appSummaryCard({
+        classes: "govuk-!-margin-bottom-6",
+        headingLevel: 3,
+        titleText: provider.name,
+        actions: {
+          items: [{
+            href: applicationPath + "/choices/" + item.id + "/delete?referrer=" + referrer,
+            text: "Delete choice"
+          } if canAmend, {
+            href: applicationPath + "/" + item.id + "/withdraw",
+            text: "Withdraw"
+          } if canWithdraw, {
+            href: applicationPath + "/" + item.id + "/view",
+            text: "View and respond to offer"
+          } if canRespond and not hasResponded]
+        } if canAmend or canWithdraw or canRespond,
+        html: courseHtml
+      }) }}
+    {% endset %}
+
+    {% set dateToday = "_" | dateNow | date %}
+    {% set dateCourseOpens = item.openFrom | date %}
+
+    {% if dateCourseOpens > dateToday or item.full == true %}
+      <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-padding-top-0 govuk-!-padding-bottom-0">
+        <h2 class="govuk-heading-s app-inset-text__title">
+          {% if dateCourseOpens > dateToday %}
+            Applications for this course do not open until {{ dateCourseOpens | date("DDD") }}
+          {% else %}
+            You cannot apply to this course as it has no vacancies
+          {% endif %}
+        </h2>
+
+        <p class="govuk-body">
+          {% if dateCourseOpens > dateToday %}
+            You can wait until applications open or change your course choice.
+          {% else %}
+            Contact the training provider to discuss alternatives or change your course choice.
+          {% endif %}
+        </p>
+
+        {{ courseSummaryCard | safe }}
+      </div>
+    {% else %}
+      {{ courseSummaryCard | safe }}
+    {% endif %}
+
+
+
+
   {% endfor %}
+
 {% else %}
   {% if showIncomplete %}
     {{ appSuggestion({

--- a/app/views/admin/states.html
+++ b/app/views/admin/states.html
@@ -19,6 +19,8 @@
     <dd>The candidate has started editing but has not submitted the form yet.</dd>
     <dt><a href="/application/12346">Form started but unsubmitted (apply again)</a></dt>
     <dd>The candidate has started apply again but has not submitted the form yet.</dd>
+    <dt><a href="/application/19415">Added courses not open and a course that is full</a></dt>
+    <dd>The candidate gets messages advising them why they can't apply</dd>
   </dl>
 
   <h2 class="govuk-heading-m">Post-submission</h2>

--- a/app/views/application/choices/delete.html
+++ b/app/views/application/choices/delete.html
@@ -1,0 +1,19 @@
+{% extends "_form.html" %}
+
+{% set title = "Are you sure you want to delete this course choice?" %}
+{% set formaction = "/application/" + applicationId + "/choices/" + id + "/delete" %}
+{% set backLinkHref = "/application/" + applicationId + "/choices" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: backLinkHref
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  {{ govukButton({
+    text: "Yes I’m sure - delete this course choice",
+    classes: "govuk-button--warning"
+  }) }}
+  <p class="govuk-body"><a href="{{ backLinkHref }}" class="govuk-link">Cancel</a></p>
+{% endblock %}

--- a/app/views/application/review.html
+++ b/app/views/application/review.html
@@ -145,9 +145,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if cannotSubmitReasons.length == 1 %}
-        <p class="govuk-body">You cannot submit this application as {{ cannotSubmitReasons[0] }}.</p>
+        <p class="govuk-body">You cannot submit this application because {{ cannotSubmitReasons[0] }}.</p>
       {% else %}
-        <p class="govuk-body">You cannot submit this application as:</p>
+        <p class="govuk-body">You cannot submit this application because:</p>
         <ul class="govuk-list govuk-list--bullet">
         {% for reason in cannotSubmitReasons %}
           <li>{{ reason }}</li>
@@ -155,7 +155,6 @@
         </ul>
     </div>
   </div>
-
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/app/views/application/review.html
+++ b/app/views/application/review.html
@@ -129,9 +129,9 @@
       {% set course = provider.courses[choice.courseCode] %}
 
       {% if dateCourseOpens > dateToday %}
-        {% set cannotSubmitReasons = cannotSubmitReasons | push(course.name_and_code + " will not open for applications until " + (choice.openFrom | date("DDD"))) %}
+        {% set cannotSubmitReasons = cannotSubmitReasons | push("you can only apply for " + course.name_and_code + " from " + (choice.openFrom | date("DDD"))) %}
       {% else %}
-        {% set cannotSubmitReasons = cannotSubmitReasons | push(course.name_and_code + " has no vacancies") %}
+        {% set cannotSubmitReasons = cannotSubmitReasons | push("there are no places left on the " + course.name_and_code + " course") %}
       {% endif %}
 
     {% endif %}
@@ -142,11 +142,20 @@
       text: "Continue"
     }) if not closed }}
   {% else %}
-    <p class="govuk-body">You cannot submit this application as:</p>
-    <ul class="govuk-list govuk-list--bullet">
-    {% for reason in cannotSubmitReasons %}
-      <li>{{ reason }}</li>
-    {% endfor %}
-    </ul>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if cannotSubmitReasons.length == 1 %}
+        <p class="govuk-body">You cannot submit this application as {{ cannotSubmitReasons[0] }}.</p>
+      {% else %}
+        <p class="govuk-body">You cannot submit this application as:</p>
+        <ul class="govuk-list govuk-list--bullet">
+        {% for reason in cannotSubmitReasons %}
+          <li>{{ reason }}</li>
+        {% endfor %}
+        </ul>
+    </div>
+  </div>
+
+    {% endif %}
   {% endif %}
 {% endblock %}

--- a/app/views/application/review.html
+++ b/app/views/application/review.html
@@ -116,7 +116,37 @@
     {% include "_includes/review/safeguarding.html" %}
   </section>
 
-  {{ govukButton({
-    text: "Continue"
-  }) if not closed }}
+  {% set dateToday = "_" | dateNow | date %}
+  {% set canSubmit = true %}
+  {% set cannotSubmitReasons = [] %}
+
+  {% set choices = applicationValue("choices") | toArray %}
+  {% for choice in choices %}
+    {% set dateCourseOpens = choice.openFrom | date %}
+    {% if dateCourseOpens > dateToday or choice.full == true %}
+      {% set canSubmit = false %}
+      {% set provider = providers[choice.providerCode] %}
+      {% set course = provider.courses[choice.courseCode] %}
+
+      {% if dateCourseOpens > dateToday %}
+        {% set cannotSubmitReasons = cannotSubmitReasons | push(course.name_and_code + " will not open for applications until " + (choice.openFrom | date("DDD"))) %}
+      {% else %}
+        {% set cannotSubmitReasons = cannotSubmitReasons | push(course.name_and_code + " has no vacancies") %}
+      {% endif %}
+
+    {% endif %}
+  {% endfor %}
+
+  {% if canSubmit %}
+    {{ govukButton({
+      text: "Continue"
+    }) if not closed }}
+  {% else %}
+    <p class="govuk-body">You cannot submit this application as:</p>
+    <ul class="govuk-list govuk-list--bullet">
+    {% for reason in cannotSubmitReasons %}
+      <li>{{ reason }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
This would allow candidates to add courses which aren't yet open for applications, but would warn them and prevent the application being submitted.

This would hopefully make it more obvious (than just not allowing them to find the course in the dropdowns/radios), and allows candidates to get their whole application ready, waiting for the course to open. Alternatively they can choose a different course.

We can use the same approach for when a course is "full" / has no vacancies.

🗂️ [Trello card](https://trello.com/c/l7u2mGiK/762-allow-candidates-to-add-courses-not-yet-open-to-their-application-but-not-submit-the-application-yet)
➡️  [Preview](https://apply-tt-pr-726.herokuapp.com/application/19415)


## Course choice page / application review

![courses page](https://user-images.githubusercontent.com/30665/196690812-a54c89a0-4996-42e7-bbad-85f245c12e76.png)

## Content replacing the submit button on the application review page

<img width="755" alt="Screenshot 2022-10-11 at 15 02 29" src="https://user-images.githubusercontent.com/30665/195112510-94d4dfe7-cd4e-47c5-988c-69840bcce4b1.png">

