### PR TITLE
Survey users on whether provider rejection feedback is helpful

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,21 +7,19 @@ document.addEventListener('DOMContentLoaded', function () {
   window.GOVUKFrontend.initAll()
 })
 
-
-function setupFeedbackButtons() {
+function setupFeedbackButtons () {
   var feedbackButtons = document.querySelectorAll('*[data-feedback]')
 
   for (feedbackButton of feedbackButtons) {
-    feedbackButton.addEventListener('click', function(event) {
-
+    feedbackButton.addEventListener('click', function (event) {
       var feedbackElement = event.target.parentElement
 
       var feedback = event.target.getAttribute('data-feedback')
 
-      if (feedback == "Yes") {
-        feedbackElement.innerHTML = "You said that this feedback is helpful."
+      if (feedback == 'Yes') {
+        feedbackElement.innerHTML = 'You said that this feedback is helpful.'
       } else {
-        feedbackElement.innerHTML = "You said that this feedback is not helpful."
+        feedbackElement.innerHTML = 'You said that this feedback is not helpful.'
       }
 
       event.preventDefault()
@@ -29,6 +27,6 @@ function setupFeedbackButtons() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   setupFeedbackButtons()
 })

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,3 +6,29 @@ if (window.console && window.console.info) {
 document.addEventListener('DOMContentLoaded', function () {
   window.GOVUKFrontend.initAll()
 })
+
+
+function setupFeedbackButtons() {
+  var feedbackButtons = document.querySelectorAll('*[data-feedback]')
+
+  for (feedbackButton of feedbackButtons) {
+    feedbackButton.addEventListener('click', function(event) {
+
+      var feedbackElement = event.target.parentElement
+
+      var feedback = event.target.getAttribute('data-feedback')
+
+      if (feedback == "Yes") {
+        feedbackElement.innerHTML = "You said that this feedback is helpful."
+      } else {
+        feedbackElement.innerHTML = "You said that this feedback is not helpful."
+      }
+
+      event.preventDefault()
+    })
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  setupFeedbackButtons()
+})

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -96,3 +96,16 @@ $govuk-assets-path: '/govuk/assets/';
 .app-button--link:hover {
   background: transparent;
 }
+
+
+.app-feedback {
+  line-height: 38px;
+}
+
+.app-feedback .govuk-button {
+  margin-bottom: 0;
+}
+
+.app-\!-colour-secondary {
+  color:  $govuk-secondary-text-colour;
+}

--- a/app/views/_includes/item/feedback.html
+++ b/app/views/_includes/item/feedback.html
@@ -52,7 +52,7 @@
   {% endset %}
 
   {{ govukInsetText({
-    classes: "app-inset-text--narrow-border govuk-!-margin-top-0",
+    classes: "app-inset-text--narrow-border govuk-!-margin-top-0  govuk-!-margin-bottom-1",
     html: qualityOfApplicaitonFeedback
   }) }}
 {% endif %}
@@ -88,7 +88,7 @@
   {% endset %}
 
   {{ govukInsetText({
-    classes: "app-inset-text--narrow-border govuk-!-margin-top-0",
+    classes: "app-inset-text--narrow-border govuk-!-margin-top-0  govuk-!-margin-bottom-1",
     html: qualificationsFeedbackHtml | safe
   }) }}
 
@@ -98,7 +98,20 @@
 <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Additional feedback</h4>
 
 {{ govukInsetText({
-  classes: "app-inset-text--narrow-border govuk-!-margin-top-0",
+  classes: "app-inset-text--narrow-border govuk-!-margin-top-0 govuk-!-margin-bottom-1",
   text: item.feedback.additionalFeedback | nl2br | safe
 }) }}
+{% endif %}
+
+{% if item.feedback %}
+  <div class="govuk-button-group app-feedback">
+    <span class="">Is this feedback helpful?</span>
+  <button class="govuk-button govuk-button--secondary govuk-!-margin-left-3" data-feedback="Yes" data-module="govuk-button">
+    Yes
+  </button>
+
+  <button class="govuk-button govuk-button--secondary" data-feedback="No" data-module="govuk-button">
+    No
+  </button>
+</div>
 {% endif %}


### PR DESCRIPTION
This would add some buttons to allow candidates to say whether the feedback given when they are rejected is helpful or not.

🗂️ [Trello card](https://trello.com/c/Mg1wH7xS/700-ask-candidates-whether-providers-rejection-feedback-was-useful)

In the dashboard, a single question would be shown beneath the feedback:

<img width="661" alt="Screenshot 2022-10-11 at 16 45 57" src="https://user-images.githubusercontent.com/30665/195138593-caf79679-50e7-45e4-82a3-bdb5539b3750.png">

Clicking a button would replace the buttons and text with a confirmation message:

<img width="652" alt="Screenshot 2022-10-11 at 16 46 35" src="https://user-images.githubusercontent.com/30665/195138747-93167dc7-57e1-49b9-855f-eba29e81fa93.png">

...or if they said it was not helpful:

<img width="650" alt="Screenshot 2022-10-11 at 16 47 02" src="https://user-images.githubusercontent.com/30665/195138833-792972af-88c3-49d1-b25f-be420937708a.png">

(Ideally we'd do this via javascript to avoid a page reload)