### PR TITLE
SKE courses: move link to directory within "Select" page

### DIFF
--- a/app/views/accepted/index.html
+++ b/app/views/accepted/index.html
@@ -174,15 +174,11 @@
 
           <p class="govuk-body">The course will be free and you’ll receive £175 per week.</p>
 
-          <p class="govuk-body"><a href="https://www.gov.uk/government/publications/subject-knowledge-enhancement-course-directory/subject-knowledge-enhancement-ske-course-directory" class="govuk-link" target="_new">Find a training provider (opens in a new tab)</a>.</p>
-
-
           <p class="govuk-body">Contact {{ providerName }} if you have any questions.</p>
 
             {{ govukButton({
               href: "/accepted/" + applicationId + "/select-ske-provider",
-              text: "Select a training provider",
-              classes: "govuk-button--secondary"
+              text: "Select a training provider"
             }) }}
         {% endif %}
 

--- a/app/views/accepted/select-ske-provider.html
+++ b/app/views/accepted/select-ske-provider.html
@@ -10,15 +10,24 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+      <h1 class="govuk-heading-l">Selecting a training provider</h1>
+
+      <p class="govuk-body">You can choose which training provider to do your 20 week maths course with.</p>
+
+      <p class="govuk-body">Most are online. Others include face to face learning or a blend of both.</p>
+
+      <p class="govuk-body">Contact University of Sussex if you need advice.</p>
+
+      <p class="govuk-body"><a href="https://www.gov.uk/government/publications/subject-knowledge-enhancement-course-directory/subject-knowledge-enhancement-ske-course-directory" class="govuk-link" target="_new">Find a training provider (opens in a new tab)</a>.</p>
 
       <form action="/accepted/{{ applicationId }}/confirm-ske-provider" method="get">
         {{ govukRadios({
           name: "skeProvider",
           fieldset: {
             legend: {
-              text: "Which training provider do you want to do your 20 week maths course with?",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
+              text: "Which training provider do you want to do your course with?",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--m"
             }
           },
           items: [

--- a/app/views/accepted/select-ske-provider.html
+++ b/app/views/accepted/select-ske-provider.html
@@ -14,7 +14,7 @@
 
       <p class="govuk-body">You can choose which training provider to do your 20 week maths course with.</p>
 
-      <p class="govuk-body">Most are online. Others include face to face learning or a blend of both.</p>
+      <p class="govuk-body">Most are online. Others include face to face learning or a mixture of both.</p>
 
       <p class="govuk-body">Contact University of Sussex if you need advice.</p>
 


### PR DESCRIPTION
This moves the link to the SKE course directory from the main post-offer interface to within the "Select a provider" screen.

The button is now also green.

## Screenshots

### Section on main screen

<img width="783" alt="Screenshot 2022-11-30 at 11 08 27" src="https://user-images.githubusercontent.com/30665/204780800-fcbec751-f82b-42cc-8cf6-a727f2b877e4.png">

### Selecting a provider

<img width="834" alt="Screenshot 2022-11-30 at 11 09 00" src="https://user-images.githubusercontent.com/30665/204780907-c6179837-18a4-4c2a-b86d-62461981b16a.png">
