### PR TITLE
Unconditional offer guidance

### DIFF
--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -55,6 +55,13 @@ module.exports = router => {
           { title: 'Disclosure and barring service check', status: 'Pending' }
         ]
         break
+      case 'offer-received-no-conditions':
+        choices.ABCDE.status = 'Offer received'
+        choices.ABCDE.interview = null
+        choices.ABCDE.feedback = null
+        choices.ABCDE.rejectedByDefault = false
+        choices.ABCDE.conditions = []
+        break
       case 'offer-received-different-course':
         choices.ABCDE.status = 'Offer received'
         choices.ABCDE.offeredCourseId = '3C2X'

--- a/app/views/_includes/item/offer.html
+++ b/app/views/_includes/item/offer.html
@@ -1,7 +1,7 @@
 {% set conditionsHtml %}
   {% set item = choice %}
 
-  {% if item.conditions %}
+  {% if item.conditions | length > 0 %}
     <ul class="govuk-list govuk-list--bullet">
       {% for condition in item.conditions %}
         <li>{{ condition.title }}</li>
@@ -9,6 +9,10 @@
     </ul>
     <p class="govuk-body">Contact the provider to find out more about these conditions.</p>
     <p class="govuk-body">They’ll confirm your place once you’ve met the conditions and they’ve checked your references.</p>
+    {% else %}
+      <p class="govuk-body">Contact the provider to find out more about any conditions.</p>
+      <p class="govuk-body">They’ll confirm your place once you’ve met any conditions and they’ve checked your references.</p>
+
   {% endif %}
 {% endset %}
 
@@ -30,6 +34,8 @@
 {% set skeHtml %}
   You’ll need to complete a 20&nbsp;week maths course.
 {% endset %}
+
+{% set skeCondition = false %}
 
 
 {{ govukSummaryList({
@@ -76,9 +82,9 @@
     value: {
       html: skeHtml
     }
-  }, {
+  } if ske, {
     key: {
-      text: "Other conditions"
+      text: ("Other conditions" if ske else "Conditions")
     },
     value: {
       html: conditionsHtml

--- a/app/views/accepted/index.html
+++ b/app/views/accepted/index.html
@@ -46,12 +46,16 @@
         <li>
           received your references
         </li>
-        <li>
-          confirmed you’ve completed your 20 week maths course
-        </li>
-        <li>
-          marked your offer conditions as met
-        </li>
+        {% if ske %}
+          <li>
+            confirmed you’ve completed your 20 week maths course
+          </li>
+        {% endif %}
+        {% if acceptedChoice.conditions | length > 0 %}
+          <li>
+            marked your offer conditions as met
+          </li>
+        {% endif %}
       </ul>
 
       <h2 class="govuk-heading-m govuk-!-padding-top-4">References</h2>
@@ -127,6 +131,7 @@
           }) }}
         </div>
 
+        {% if ske %}
 
         <h2 class="govuk-heading-m">Study before you start training</h2>
 
@@ -182,6 +187,7 @@
             }) }}
         {% endif %}
 
+      {% endif %}
       {% if acceptedChoice.conditions | length > 0 %}
         <h2 class="govuk-heading-m">Other conditions</h2>
 

--- a/app/views/admin/states.html
+++ b/app/views/admin/states.html
@@ -36,6 +36,8 @@
     <dd>Candidate needs to wait</dd>
     <dt><a href="/dashboard/45678/offer-received">Received an offer with conditions</a></dt>
     <dd>Candidate needs to respond to the offer</dd>
+    <dt><a href="/dashboard/45678/offer-received-no-conditions">Received an offer with no conditions</a></dt>
+    <dd>Candidate needs to respond to the offer</dd>
     <dt><a href="/dashboard/45678/offer-received-different-course">Received an an offer for a different course</a></dt>
     <dd>Candidate needs to respond to the offer</dd>
     <dt><a href="/dashboard/45678/offer-received-different-provider">Received an an offer for a course from a different provider</a></dt>

--- a/app/views/dashboard/_course-choices.html
+++ b/app/views/dashboard/_course-choices.html
@@ -113,6 +113,10 @@
       </ul>
       <p class="govuk-body">Contact the provider to find out more about these conditions.</p>
       <p class="govuk-body">They’ll confirm your place once you’ve met the conditions and they’ve checked your references.</p>
+    {% else %}
+      <p class="govuk-body">Contact the provider to find out more about any conditions.</p>
+      <p class="govuk-body">They’ll confirm your place once you’ve met any conditions and they’ve checked your references.</p>
+
     {% endif %}
   {% endset %}
 
@@ -187,14 +191,14 @@
           value: {
             html: skeHtml
           }
-        } if item.status == 'Offer received', {
+        } if skeCondition, {
         key: {
-          text: "Other conditions"
+          text: "Conditions"
         },
         value: {
           html: conditionsHtml | safe
         }
-      } if item.status != 'Awaiting decision' and item.conditions, {
+      } if item.status != 'Awaiting decision', {
         key: {
           classes: "govuk-visually-hidden",
           text: "Actions"


### PR DESCRIPTION
This changes the view for "unconditional" offers, where no conditions are set in Manage or via the API, so that we always display some guidance text about reference being checked, and any other conditions which may have been mentioned off-service.

🗂️ [Trello card](https://trello.com/c/55tomdM9/900-mention-references-for-an-unconditional-offer-on-candidate-dashboard-and-details-of-offer-page)

## Screenshots

### Before

<img width="975" alt="Screenshot 2022-12-09 at 13 40 04" src="https://user-images.githubusercontent.com/30665/206715476-be86252a-5cb9-423c-84f3-302806b69f1f.png">

### After

<img width="986" alt="Screenshot 2022-12-09 at 13 43 55" src="https://user-images.githubusercontent.com/30665/206715685-a94f90c7-3781-4f04-82c3-1d2abcb309ac.png">
