### PR TITLE
Tweak success message

### DIFF
--- a/app/views/dashboard/index.html
+++ b/app/views/dashboard/index.html
@@ -25,9 +25,8 @@
     {% if confirmation == "true" %}
       {% set html %}
         <h3 class="govuk-notification-banner__heading">
-          Application successfully submitted
+          Application submitted
         </h3>
-        <p class="govuk-body"> You will get an email when something changes.</p>
       {% endset %}
 
       {{ govukNotificationBanner({
@@ -67,6 +66,9 @@
           {% else %}
             <p class="govuk-body">Your application has been submitted and is with the training provider.</p>
           {% endif %}
+
+          <p class="govuk-body">You will be emailed when {% if choices | length > 1 %}a provider{% else %}the provider{% endif %} makes a decision.</p>
+
 
           <p class="govuk-body">Our <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training advisers</a> can help you prepare for any interviews.</p>
 


### PR DESCRIPTION
This tweaks the success message shown when submitting to:

* remove the duplicate word "successfully" (banner already has the title "Success")
* remove the line about receiving emails from the banner and move it to body text, so that it'll be shown even on later page loads
* change "when something changes" to "when the provider makes a decision" to be more specific.

Technically you'll also be emailed about other changes, eg being rejected automatically, invited to an interview, or being withdrawn (at your request) but those don't feel like they need to be explicitly mentioned.

🗂️ [Trello card](https://trello.com/c/XIuydIxs/992-improve-our-success-messaging-when-a-candidate-submits-an-application)

## Screenshots

### Before

<img width="988" alt="Screenshot 2022-12-09 at 13 57 40" src="https://user-images.githubusercontent.com/30665/206718640-3350fe74-1f92-4e61-8aa1-dacb9fa3f559.png">

### After

<img width="1027" alt="Screenshot 2022-12-09 at 13 57 24" src="https://user-images.githubusercontent.com/30665/206718662-6ed5736e-e0e2-46d1-bcc5-b13ebd2082fe.png">
