### PR TITLE
Boiler plate content for reasons for rejection

### DIFF
--- a/app/routes/application/dashboard.js
+++ b/app/routes/application/dashboard.js
@@ -334,23 +334,21 @@ module.exports = router => {
       case 'ended-without-success':
         choices.ABCDE.status = 'Unsuccessful'
         choices.ABCDE.feedback = {
-          personalStatement: {
-            qualityOfWriting: 'Contained several spelling mistakes and grammatical errors.\n\nThe candidate should describe the impact they want to have on their students in more detail.',
-            other: 'Candidate was not able to demonstrate sufficient experience of working with children.'
+          qualifications: {
+            noDegree: 'No bachelor’s degree or equivalent'
           }
         }
         choices.FGHIJ.status = 'Unsuccessful'
         choices.FGHIJ.feedback = {
-          personalStatement: {
-            other: 'Your rationale for wanting to teach was strong but your personal statement did not demonstrate that you understand the rewards and challenges of teaching. There were a number of spelling and grammar errors throughout the application.'
-          },
-          additionalFeedback: 'It would also strengthen your application if you could get more experience of working within a primary school. '
+          qualifications: {
+            noDegree: 'No bachelor’s degree or equivalent'
+          }
         }
         choices.ZYXWV.status = 'Unsuccessful'
         choices.ZYXWV.interview = null
         choices.ZYXWV.feedback = {
-          personalStatement: {
-            other: 'Focus more on why teaching is the career for you.'
+          teachingKnowledge: {
+            teachingMethod: 'Did not have adequate teaching skills in their demonstration.'
           }
         }
         break

--- a/app/views/_includes/item/feedback.html
+++ b/app/views/_includes/item/feedback.html
@@ -27,6 +27,14 @@
 {% endif %}
 {% endif %}
 
+{% if item.feedback.teachingKnowledge %}
+  <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Teaching knowledge and ability</h4>
+  {% if item.feedback.teachingKnowledge.teachingMethod %}
+  <p class="govuk-body">Teaching method knowledge</p>
+  {{item.feedback.teachingKnowledge.teachingMethod}}
+  {% endif %}
+{% endif %}
+
 {% if item.feedback.performanceAtInterview %}
 <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Performance at interview</h4>
 
@@ -75,7 +83,8 @@
     {% endif %}
 
     {% if item.feedback.qualifications.noDegree %}
-      <p class="govuk-body">No degree.</p>
+      <p class="govuk-body">No bachelor’s degree or equivalent.
+</p>
     {% endif %}
 
     {% if item.feedback.qualifications.degreeDoesNotMeetRequirements %}

--- a/app/views/dashboard/_apply-again.html
+++ b/app/views/dashboard/_apply-again.html
@@ -28,14 +28,14 @@
 
 <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
  {% if showTrainTeachNoDegree %}
-    <li>Train to teach without a degree by doing an <a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree">undergraduate degree in teacher training</a> or becoming a <a href="https://getintoteaching.education.gov.uk/become-a-further-education-teacher">further education teacher</a>.</li>
+    <li>Train to teach by doing an <a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree">undergraduate degree in teacher training</a> or becoming a <a href="https://getintoteaching.education.gov.uk/become-a-further-education-teacher">further education teacher</a>.</li>
  {% endif %} 
  {% if showGetSchoolExperience %}
-    <li><a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience">Get school experience</a> in a real school, so you can find out what it’s like to be a teacher and improve your knowledge and skills.</li>
+    <li><a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience">Get school experience</a> in a classroom, so you can find out what it’s like to be a teacher and improve your knowledge and skills.</li>
  {% endif %} 
 </ul>
 
- <p class="govuk-body">To talk about your application and training options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
+<p class="govuk-body">To talk about your application and training options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
 
   {{ govukButton({
     text: "Apply again",

--- a/app/views/dashboard/_apply-again.html
+++ b/app/views/dashboard/_apply-again.html
@@ -19,7 +19,7 @@
   
     </ul>
 
-  <p class="govuk-body">To talk about your options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
+  <p class="govuk-body">To talk about your application and training options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
 
   {{ govukButton({
     text: "Apply again",

--- a/app/views/dashboard/_apply-again.html
+++ b/app/views/dashboard/_apply-again.html
@@ -11,6 +11,22 @@
 
   <p class="govuk-body">If now’s the right time, you can still apply for courses that start this academic year.</p>
 
+  <p class="govuk-body">Here’s what you could do next:</p>
+
+    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+
+    <li>Find another course with a training provider that will accept an equivalency test. You can also take your GCSE exams at any age if you do not have them or you can retake them to improve your grades.</li>
+
+    <li>Train to teach without a degree by doing an <a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree">undergraduate degree</a> in teacher training or becoming a <a href="https://getintoteaching.education.gov.uk/become-a-further-education-teacher">further education</a> teacher.</li>
+
+    <li>Improve your subject knowledge, look at the <a href="https://www.gov.uk/government/collections/national-curriculum">national curriculum</a> to find out what areas you need to know more about. You can also find a course in a different subject.</li>
+
+    <li><a href="https://www.gov.uk/replacement-exam-certificate">Get a certified statement of your exam results</a> if you did your GCSEs and A levels in the UK. You should also be able to request a copy of your degree certificate from the organisation where you studied in the UK.</li>
+    
+    <li> If you got your qualifications outside the UK, you should be able to request copies of your school results and degree from the places where you did them.</li>
+  
+  </ul>
+
   <p class="govuk-body">To talk about your options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
 
   {{ govukButton({

--- a/app/views/dashboard/_apply-again.html
+++ b/app/views/dashboard/_apply-again.html
@@ -10,21 +10,32 @@
   </h2>
 
   <p class="govuk-body">If now’s the right time, you can still apply for courses that start this academic year.</p>
-  
+
   <p class="govuk-body">Here’s what you could do next:</p>
 
-    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
-      {% for item in choices %}
-{% if item.feedback.qualifications.noDegree %}
-<li>Train to teach without a degree by doing an <a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree">undergraduate degree in teacher training</a> or becoming a <a href="https://getintoteaching.education.gov.uk/become-a-further-education-teacher">further education teacher</a>.</li>
-{% endif %}
-{% if item.feedback.teachingKnowledge %}
-<li><a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience">Get school experience</a> in a real school, so you can find out what it’s like to be a teacher and improve your knowledge and skills.</li>
-{% endif %}
- {% endfor %} 
-    </ul>
+  {% set showTrainTeachNoDegree = false %}
+  {% set showGetSchoolExperience = false %}
+  
+  {% for item in choices %}
+    {% if item.feedback.qualifications.noDegree %}
+      {% set showTrainTeachNoDegree = true %}
+    {% endif %}
+    {% if item.feedback.teachingKnowledge %}
+      {% set showGetSchoolExperience = true %}
+    {% endif %}
+  {% endfor %} 
 
-  <p class="govuk-body">To talk about your application and training options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
+
+<ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+ {% if showTrainTeachNoDegree %}
+    <li>Train to teach without a degree by doing an <a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree">undergraduate degree in teacher training</a> or becoming a <a href="https://getintoteaching.education.gov.uk/become-a-further-education-teacher">further education teacher</a>.</li>
+ {% endif %} 
+ {% if showGetSchoolExperience %}
+    <li><a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience">Get school experience</a> in a real school, so you can find out what it’s like to be a teacher and improve your knowledge and skills.</li>
+ {% endif %} 
+</ul>
+
+ <p class="govuk-body">To talk about your application and training options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
 
   {{ govukButton({
     text: "Apply again",

--- a/app/views/dashboard/_apply-again.html
+++ b/app/views/dashboard/_apply-again.html
@@ -10,13 +10,18 @@
   </h2>
 
   <p class="govuk-body">If now’s the right time, you can still apply for courses that start this academic year.</p>
-
+  
   <p class="govuk-body">Here’s what you could do next:</p>
 
     <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
-
-    <li>Find out more about how <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student">visa sponsorships</a> work if you want to train to teach in the UK. You can also find a training provider that will sponsor a visa by filtering search results on ‘visa sponsorship‘ when you search for courses.</li>
-  
+      {% for item in choices %}
+{% if item.feedback.qualifications.noDegree %}
+<li>Train to teach without a degree by doing an <a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree">undergraduate degree in teacher training</a> or becoming a <a href="https://getintoteaching.education.gov.uk/become-a-further-education-teacher">further education teacher</a>.</li>
+{% endif %}
+{% if item.feedback.teachingKnowledge %}
+<li><a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience">Get school experience</a> in a real school, so you can find out what it’s like to be a teacher and improve your knowledge and skills.</li>
+{% endif %}
+ {% endfor %} 
     </ul>
 
   <p class="govuk-body">To talk about your application and training options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>

--- a/app/views/dashboard/_apply-again.html
+++ b/app/views/dashboard/_apply-again.html
@@ -15,17 +15,9 @@
 
     <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
 
-    <li>Find another course with a training provider that will accept an equivalency test. You can also take your GCSE exams at any age if you do not have them or you can retake them to improve your grades.</li>
-
-    <li>Train to teach without a degree by doing an <a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree">undergraduate degree</a> in teacher training or becoming a <a href="https://getintoteaching.education.gov.uk/become-a-further-education-teacher">further education</a> teacher.</li>
-
-    <li>Improve your subject knowledge, look at the <a href="https://www.gov.uk/government/collections/national-curriculum">national curriculum</a> to find out what areas you need to know more about. You can also find a course in a different subject.</li>
-
-    <li><a href="https://www.gov.uk/replacement-exam-certificate">Get a certified statement of your exam results</a> if you did your GCSEs and A levels in the UK. You should also be able to request a copy of your degree certificate from the organisation where you studied in the UK.</li>
-    
-    <li> If you got your qualifications outside the UK, you should be able to request copies of your school results and degree from the places where you did them.</li>
+    <li>Find out more about how <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student">visa sponsorships</a> work if you want to train to teach in the UK. You can also find a training provider that will sponsor a visa by filtering search results on ‘visa sponsorship‘ when you search for courses.</li>
   
-  </ul>
+    </ul>
 
   <p class="govuk-body">To talk about your options, get in touch with a <a href="https://beta-adviser-getintoteaching.education.gov.uk/">teacher training adviser</a>.</p>
 


### PR DESCRIPTION
When a provider rejects a candidate, we want to show some text to help the candidate take the next step and keep them in the application journey. We also know that sometimes the rejection reasons from providers is not helpful.
Trello ticket: https://trello.com/c/zmcV9v7v/495-r4r-draft-boiler-plate-feedback-text

When all 3 applications are unsuccessful, we would show some 'boiler plate' content above the applications to help them onto the next step.

Image below shows the text above the rejected applications, each bullet point would only show depending in what 'rejection reason' a provider chooses. From analysis, the majority of providers only ever select 1 or 2 reasons. So in the screenshot below a candidate would mostly only see 1 or 2 bullet points (I've included more just to see what it would look like).

<img width="760" alt="Screenshot 2022-12-09 at 14 34 08" src="https://user-images.githubusercontent.com/68232608/206726434-9a786c3c-5782-4a66-8b67-84237f16aa49.png">
