### PR TITLE
Adding SKE info to other places in apply

### DIFF
--- a/app/views/application/subject-knowledge/index.html
+++ b/app/views/application/subject-knowledge/index.html
@@ -20,6 +20,8 @@
 {% block primary %}
   <p class="govuk-body">If you’re applying for secondary teacher training, describe your knowledge of the subjects you’d like to teach.</p>
 
+  <p class="govuk-body">You may be able to do a <a href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement">subject knowledge enhancement (SKE)</a> course before you start training.</p>
+
   <p class="govuk-body">If you’re applying for primary teacher training, say why you’d like to teach this age group.</p>
 
   <p class="govuk-body">If you're applying for a primary course with a subject specialism, or you're particularly interested in certain primary subjects, you can also talk about that.</p>
@@ -32,8 +34,7 @@
     <li>any relevant skills, interests or achievements</li>
     <li>your understanding of the national curriculum</li>
   </ul>
-
-  <p class="govuk-body">If you need help, you can speak to our <a href="https://getintoteaching.education.gov.uk/teacher-training-advisers">teacher training advisers</a>. Our advisors were teachers and they can give you free, one-to-one support with your personal statement.</p>
+  
   {{ govukCharacterCount({
     label: {
       text: "Why are you suited to teach your subjects or age group?",


### PR DESCRIPTION
Exploring where else we could add info about subject knowledge enhancement (SKE) courses.

We've looked at various places we could add this information, and mocked up one option on the 'Suitability to teach a subject or age group' - this feels like the only place we could add more info. See screenshot below. 

However, it still doesn't feel quite right to say this here, it has nothing to do with what we're asking candidates to do here. Also, not everyone can do an SKE, so do we want to send people away at this point to the GIT page - rather let them fill out the form.

If we did conditional content, it feels like a lot of work for a very small amount of text, that we're not sure people will even read. We could only do conditional text if we know what course the candidate has chosen, however there is no guarantee that a candidate might start this section before choosing a course.

![Screenshot 2023-01-13 at 13 58 15](https://user-images.githubusercontent.com/68232608/212339287-3d93cb04-cef6-49a7-988f-f15e08ef2e00.png)

Further comments about the other areas we explored are in this trello ticket: https://trello.com/c/rc1jMLja/1075-investigate-where-else-we-could-surface-ske-information-for-candidates