### PR TITLE
O level qualifications

### DIFF
--- a/app/views/application/gcse/index.html
+++ b/app/views/application/gcse/index.html
@@ -72,7 +72,7 @@
           items: [{
             text: "GCSE"
           }, {
-            text: "O level"
+            text: "UK O level (from before 1989)"
           }, {
             text: "Scottish National 5"
           }, {
@@ -81,14 +81,16 @@
               html: otherUkConditionalHtml
             }
           }, {
-            text: "A non-UK qualification",
+            divider: "or"
+          }, {
+            text: "Qualification from outside the UK",
             conditional: {
               html: nonUkConditionalHtml
             }
           }, {
             divider: "or"
           }, {
-            text: "I do not have a GCSE in " + subject + " (or equivalent) yet",
+            text: "I do not have a qualification in " + subject + " yet",
             value: "not-yet"
           }]
         } | decorateApplicationAttributes(["gcse", id, "type"])) }}

--- a/app/views/application/references/index.html
+++ b/app/views/application/references/index.html
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
 
-      <p class="govuk-body">You need to give details of 2 people who can give a reference for you. They’ll be only be contacted if you accept an offer.</p>
+      <p class="govuk-body">You need to give the email address of 2 people who can give a reference for you. They’ll be only be contacted if you accept an offer.</p>
 
       <p class="govuk-body">You should include:</p>
 


### PR DESCRIPTION
When checking validation errors, we noticed a lot of candidates from Nigeria are adding in their Nigerian O level grades to the 'O level section' under qualifications. There is nothing to distinguich that we're asking for UK O levels. They should be adding in their level results in the 'non-UK qualification' section. We've made some small tweaks to make this clearer for people.

Changed:

- 'O levels' to 'UK O level (before 1989)'
- separated 'non UK qualifications' by using an 'or' and renaming it to 'Qualification from outside the UK'


https://trello.com/c/NGfBFZFn/1161-make-it-clearer-that-o-level-means-a-uk-o-level-and-not-a-nigerian-one

<img width="762" alt="Screenshot 2023-02-17 at 14 51 53" src="https://user-images.githubusercontent.com/68232608/219687644-3633313c-e54f-4d3a-817a-01ea817fa1eb.png">
