### PR TITLE
Add navigation bar and change header

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -5,6 +5,7 @@
 @import "components/section";
 @import "components/phase-banner";
 @import "components/header";
+@import "components/secondary-nav";
 
 .govuk-body {
   word-wrap: break-word;
@@ -79,43 +80,5 @@
 
 .app-\!-background-grey {
   background-color: govuk-colour("light-grey");
-}
-
-.app-secondary-nav {
-  display: table;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.app-secondary-nav__nav {
-  display: table-cell;
-}
-
-.app-secondary-nav a {
-  display: inline-block;
-  text-decoration: none;
-  font-weight: bold;
-}
-
-.app-secondary-nav__nav a {
-  padding: 10px 0 5px 0;
-  margin-right: 15px;
-}
-
-.app-secondary-nav__nav a[aria-current] {
-  border-bottom: #1d70b8 5px solid;
-}
-
-.app-secondary-nav__sign-out {
-  display: table-cell;
-  text-align: right;
-}
-
-
-@include govuk-media-query($from: tablet) {
-  .app-secondary-nav__nav a {
-    padding: 15px 0 10px 0;
-    margin-right: 30px;
-  }
 }
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -73,3 +73,43 @@
 .app-\!-colour-secondary {
   color:  $govuk-secondary-text-colour;
 }
+
+
+.app-secondary-nav {
+  display: table;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.app-secondary-nav__nav {
+  display: table-cell;
+}
+
+.app-secondary-nav a {
+  display: inline-block;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.app-secondary-nav__nav a {
+  padding: 10px 0 5px 0;
+  margin-right: 15px;
+}
+
+.app-secondary-nav__nav a[aria-current] {
+  border-bottom: #1d70b8 5px solid;
+}
+
+.app-secondary-nav__sign-out {
+  display: table-cell;
+  text-align: right;
+}
+
+
+@include govuk-media-query($from: tablet) {
+  .app-secondary-nav__nav a {
+    padding: 15px 0 10px 0;
+    margin-right: 30px;
+  }
+}
+

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -3,6 +3,7 @@
 @import "components/hidden-link";
 @import "components/inset-text";
 @import "components/section";
+@import "components/phase-banner";
 
 .govuk-body {
   word-wrap: break-word;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -4,6 +4,7 @@
 @import "components/inset-text";
 @import "components/section";
 @import "components/phase-banner";
+@import "components/header";
 
 .govuk-body {
   word-wrap: break-word;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -75,6 +75,10 @@
 }
 
 
+.app-\!-background-grey {
+  background-color: govuk-colour("light-grey");
+}
+
 .app-secondary-nav {
   display: table;
   width: 100%;

--- a/app/assets/sass/components/_header.scss
+++ b/app/assets/sass/components/_header.scss
@@ -1,0 +1,12 @@
+
+.app-header--full-width-blue-border {
+  border-bottom-width: 0;
+}
+
+.app-header--full-width-blue-border:after {
+  content: '';
+  width: 100%;
+  display: block;
+  height: 10px;
+  background-color:  govuk-colour("blue");
+}

--- a/app/assets/sass/components/_phase-banner.scss
+++ b/app/assets/sass/components/_phase-banner.scss
@@ -1,0 +1,4 @@
+
+.app-phase-banner--no-border {
+  border-bottom-width: 0;
+}

--- a/app/assets/sass/components/_secondary-nav.scss
+++ b/app/assets/sass/components/_secondary-nav.scss
@@ -1,0 +1,38 @@
+
+.app-secondary-nav {
+  display: table;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.app-secondary-nav__nav {
+  display: table-cell;
+}
+
+.app-secondary-nav a {
+  display: inline-block;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.app-secondary-nav__nav a {
+  padding: 10px 0 5px 0;
+  margin-right: 15px;
+}
+
+.app-secondary-nav__nav a[aria-current] {
+  border-bottom: #1d70b8 5px solid;
+}
+
+.app-secondary-nav__sign-out {
+  display: table-cell;
+  text-align: right;
+}
+
+
+@include govuk-media-query($from: tablet) {
+  .app-secondary-nav__nav a {
+    padding: 15px 0 10px 0;
+    margin-right: 30px;
+  }
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -34,6 +34,9 @@ router.post('/application/apply-again', (req, res) => {
 
 // Submit application action
 router.post('/application/submit', (req, res) => {
+
+  req.session.data.submittedAt = (new Date()).toISOString()
+
   // Set status of each choice to 'Awaiting decision'
   const choices = req.session.data.choices
   if (choices) {

--- a/app/views/account/change-email-address.html
+++ b/app/views/account/change-email-address.html
@@ -3,6 +3,7 @@
 {% set title = "Change your email address" %}
 {% set formaction = "/account/check-email/change-email-address" %}
 {% set hasAccountLinks = false %}
+{% set signedIn = false %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/app/views/account/check-email.html
+++ b/app/views/account/check-email.html
@@ -2,6 +2,7 @@
 
 {% set title = "Check your email to sign in" if action == "sign-in" else "Check your email" %}
 {% set hasAccountLinks = false %}
+{% set signedIn = false %}
 
 {% block content %}
   <h1 class="govuk-heading-l">{{ title }}</h1>

--- a/app/views/account/create-account.html
+++ b/app/views/account/create-account.html
@@ -2,6 +2,7 @@
 
 {% set title = "Create an account" %}
 {% set formaction = "/send-email/create-account" %}
+{% set signedIn = false %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/app/views/account/index.html
+++ b/app/views/account/index.html
@@ -2,6 +2,8 @@
 
 {% set title = "Create an account or sign in" %}
 {% set hasAccountLinks = false %}
+{% set signedIn = false %}
+
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/views/account/sign-in.html
+++ b/app/views/account/sign-in.html
@@ -3,6 +3,8 @@
 {% set title = "Sign in" %}
 {% set formaction = "/send-email/sign-in" %}
 {% set hasAccountLinks = false %}
+{% set signedIn = false %}
+
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/app/views/application/index.html
+++ b/app/views/application/index.html
@@ -16,11 +16,7 @@
   {% endif %}
 {% endmacro %}
 
-{% if apply2 %}
-  {% set title = "Your new application" %}
-{% else %}
-  {% set title = "Your application" %}
-{% endif %}
+{% set title = "Your application" %}
 {% set reviewText = "Check your answers before submitting" %}
 {% set hasSecondary = true %}
 

--- a/app/views/dashboard/index.html
+++ b/app/views/dashboard/index.html
@@ -1,6 +1,6 @@
 {% extends "layouts/main.html" %}
 
-{% set choices = application.choices %}
+{% set choices = data.choices %}
 
 {% if choices | length > 1  %}
   {% set title = "Your applications" %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -5,6 +5,7 @@
 {% set hasSecondary = true %}
 {% set showPhaseBanner = false %}
 {% set serviceName = false %}
+{% set signedIn = false %}
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -3,9 +3,7 @@
 {% block header %}
   {{ govukHeader({
     classes: "app-header--full-width-blue-border",
-    homepageUrl: "/applications",
-    serviceName: serviceName,
-    navigation: []
+    serviceName: serviceName
   }) }}
 
 

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -2,14 +2,10 @@
 
 {% block header %}
   {{ govukHeader({
+    classes: "app-header--full-width-blue-border",
     homepageUrl: "/applications",
     serviceName: serviceName,
-    navigation: [{
-      text: data.account.email
-    } if data.account.email, {
-      href: "/account/sign-out",
-      text: "Sign out"
-    } if data.account.email]
+    navigation: []
   }) }}
 
 
@@ -17,9 +13,9 @@
     {{ govukPhaseBanner({
         classes: "app-phase-banner--no-border",
         tag: {
-          text: "prototype"
+          text: "beta"
         },
-        html: 'This is a prototype.'
+        html: '<a href="#" class="govuk-link">Make a complaint or give feedback</a>'
       }) if showPhaseBanner != false }}
   </div>
   {% if signedIn != false %}
@@ -27,7 +23,14 @@
      <div class="govuk-width-container">
        <div class="app-secondary-nav">
          <nav class="app-secondary-nav__nav">
-          <a class="govuk-link govuk-link--no-visited-state" aria-current="page" href="/applications">Your applications</a>
+
+        {% if (data.submittedAt) and (data.choices | length > 1)  %}
+          {% set applicationTitle = "Your applications" %}
+        {% else %}
+          {% set applicationTitle = "Your application" %}
+        {% endif %}
+
+          <a class="govuk-link govuk-link--no-visited-state" aria-current="page" href="/applications">{{ applicationTitle }}</a>
          </nav>
 
          <div class="app-secondary-nav__sign-out">

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -34,7 +34,7 @@
          </nav>
 
          <div class="app-secondary-nav__sign-out">
-           <a class="govuk-link govuk-link--no-visited-state" href="#">Sign out</a>
+           <a class="govuk-link govuk-link--no-visited-state" href="/">Sign out</a>
          </div>
        </div>
      </div>

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -11,6 +11,23 @@
       text: "Sign out"
     } if data.account.email]
   }) }}
+
+  {% if signedIn != false %}
+
+   <div class="govuk-!-font-size-19 app-!-background-grey">
+     <div class="govuk-width-container">
+       <div class="app-secondary-nav">
+         <nav class="app-secondary-nav__nav">
+          <a class="govuk-link govuk-link--no-visited-state" {% if section == "applications" %}aria-current="page"{% endif %} href="/applications">Your applications</a>
+         </nav>
+
+         <div class="app-secondary-nav__sign-out">
+           <a class="govuk-link govuk-link--no-visited-state" href="#">Sign out</a>
+         </div>
+       </div>
+     </div>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block pageTitle %}

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -12,8 +12,14 @@
     } if data.account.email]
   }) }}
 
-  {% if signedIn != false %}
 
+  {{ govukPhaseBanner({
+      tag: {
+        text: "prototype"
+      },
+      html: 'This is a prototype.'
+    }) if showPhaseBanner != false }}
+  {% if signedIn != false %}
    <div class="govuk-!-font-size-19 app-!-background-grey">
      <div class="govuk-width-container">
        <div class="app-secondary-nav">
@@ -35,12 +41,6 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukPhaseBanner({
-      tag: {
-        text: "prototype"
-      },
-      html: 'This is a prototype.'
-    }) if showPhaseBanner != false }}
 {% endblock %}
 
 {% block footer %}

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -13,18 +13,21 @@
   }) }}
 
 
-  {{ govukPhaseBanner({
-      tag: {
-        text: "prototype"
-      },
-      html: 'This is a prototype.'
-    }) if showPhaseBanner != false }}
+  <div class="govuk-width-container">
+    {{ govukPhaseBanner({
+        classes: "app-phase-banner--no-border",
+        tag: {
+          text: "prototype"
+        },
+        html: 'This is a prototype.'
+      }) if showPhaseBanner != false }}
+  </div>
   {% if signedIn != false %}
    <div class="govuk-!-font-size-19 app-!-background-grey">
      <div class="govuk-width-container">
        <div class="app-secondary-nav">
          <nav class="app-secondary-nav__nav">
-          <a class="govuk-link govuk-link--no-visited-state" {% if section == "applications" %}aria-current="page"{% endif %} href="/applications">Your applications</a>
+          <a class="govuk-link govuk-link--no-visited-state" aria-current="page" href="/applications">Your applications</a>
          </nav>
 
          <div class="app-secondary-nav__sign-out">


### PR DESCRIPTION
This adds a navigation bar to the candidate interface, even though it only has 1 item in it for now (plus "sign out"). This is to enable further items to be added when continuous applications is launched.

🗂️ [Trello card](https://trello.com/c/wFS59p9L/1502-design-the-candidate-navigation-bar)

Changes:

* No longer show email address in black header bar
* Move sign out link from black header bar to grey navigation bar, aligned right
* Add "Your application(s)" as the first (and only) navigation item, and show it as selected.

Note: For now, the capitalisation of "Your application(s)" should follow the convention used on the service, which is:

* singular when not yet submitted
* singular if submitted but there was only 1 course chocie
* plural if submitted and there were 2+ course choices
* singular when an offer has been accepted

## Screenshots

### Before

<img width="1184" alt="Screenshot 2023-05-24 at 13 57 42" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/30665/ce09d07e-9245-427a-98e3-99ea42d712fc">

### After

<img width="1184" alt="Screenshot 2023-05-24 at 15 23 01" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/30665/47dbe018-c11f-4699-8264-7cacda05a946">

