### PR TITLE
Remove "further information" question

### DIFF
--- a/app/views/application/submit.html
+++ b/app/views/application/submit.html
@@ -26,43 +26,9 @@
         html: dbsCheckHtml
       }) }}
 
-      {% set yesConditionalHtml %}
-        {{ govukCharacterCount({
-          id: "additional-information",
-          name: "additionalInformation",
-          value: data.additionalInformation,
-          label: {
-            text: "Enter further information"
-          },
-          maxwords: 300
-        }) }}
-      {% endset -%}
+      <p class="govuk-body">By sending this application to {{ providerText }}, I confirm that the information given is true, complete and accurate.</p>
 
       <form action="/application/submit" method="post">
-        {{ govukRadios({
-          name: "additionalInformationAdded",
-          value: data.additionalInformationAdded,
-          fieldset: {
-            legend: {
-              text: "Is there anything else you would like to tell us about your application?",
-              classes: "govuk-label--m"
-            },
-            attributes: {
-              "data-module": "clear-hidden"
-            }
-          },
-          items: [{
-            text: "Yes",
-            conditional: {
-              html: yesConditionalHtml
-            }
-          }, {
-            text: "No"
-          }]
-        }) }}
-
-        <p class="govuk-body">By sending this application to {{ providerText }}, I confirm that the information given is true, complete and accurate.</p>
-
         {{ govukButton({
           text: "Send application"
         }) }}


### PR DESCRIPTION
This removes the "further information" question.

🗂️ [Trello card](https://trello.com/c/q7Bhm7vC/1505-remove-the-additional-information-question)

Previous analysis showed that this was rarely used, or used in unexpected ways:

* lots of candidates use it to say that they already have a DBS certificate - however in most cases they would still be required to get a new one anyway, as they can expire, plus ITT requires an "enhanced" DBS check rather than a "basic" one.
* some candidates use it to declare safeguarding information, however this should have been declared within that section within the application itself - and adding the information here means that it might be missed, plus won't be subject to the same access controls and permission levels to view this sensitive information
* some candidates used it to add a generic sign-off such as "I look forward to hearing from you" which doesn’t add any useful content - perhaps these candidates felt compelled to say _something_

There were some more valid use cases, such as using this to tell the provider that they had been asked to re-apply following a previous application. In these instances though, this could be communicated off-service (plus we’re hoping to avoid candidates having to reapply in the first place, by changing the rules around automatic rejections).

For these reasons, we’ve decided to remove the question altogether.  This also makes the interface simpler when we come to implement "continuous applications", where each course choice would be submitted separately.

## Screenshots

### Before

<img width="1022" alt="Screenshot 2023-05-24 at 16 11 28" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/30665/4cb9e20a-4024-4230-b469-4c9e2ef3a0d0">

### After

<img width="882" alt="Screenshot 2023-05-24 at 16 12 50" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/30665/f61935e0-5deb-43e6-8397-d408aa15388a">
