### PR TITLE
Merge content about safeguarding

### DIFF
--- a/app/views/application/safeguarding/index.html
+++ b/app/views/application/safeguarding/index.html
@@ -16,17 +16,21 @@
 
       <p class="govuk-body">Teacher training providers need to check that it’s safe for you to work with children and young people.</p>
 
-      <p class="govuk-body">As well as confirming your identity and your right to work in the UK, providers will check:</p>
+      <!-- <p class="govuk-body">Providers will check:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>your criminal record in the UK (they'll do an enhanced <a href="https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks">DBS check)</a> and abroad where relevant</li>
+        <li>your criminal record in the UK and any other countries you’ve lived in recently</li>
         <li>whether you’ve been banned from teaching or working with children</li>
-        <li>your professional behaviour, such as whether you’ve been removed from teacher training and what your referees say about you</li>
-      </ul>
+        <li>your professional behaviour, such as by asking for a reference from people you’ve worked with</li>
+      </ul> -->
 
-      <p class="govuk-body">Tell your provider about any potential safeguarding issues, such as offences, cautions, reprimands and final warnings. They can give advice about whether this will affect your application.</p>
+      <p class="govuk-body">Tell providers about any potential safeguarding issues, such as offences, cautions, reprimands and final warnings.</p>
 
-      <p class="govuk-body">It won’t necessarily stop you becoming a teacher.</p>
+      <p class="govuk-body">Not all convictions will prevent you from training to be a teacher.</p>
+
+      <p class="govuk-body">Talk to the providers you’re applying to for advice on whether any safeguarding issues will affect your application.</p>
+
+      <p class="govuk-body"><a href="https://www.gov.uk/tell-employer-or-college-about-criminal-record">Learn more about when you need to tell someone about your criminal record</a>.</p>
 
       {% set safeguardingHtml %}
         {{ govukCharacterCount({
@@ -48,16 +52,13 @@
           fieldset: {
             classes: "govuk-!-margin-top-7",
             legend: {
-              text: "Do you want to share any safeguarding issues?",
+              text: "Do you want to declare any safeguarding issues, such as a criminal record or professional misconduct?",
               classes: "govuk-fieldset__legend--m"
             }
           },
           items: [{
             value: "yes",
             text: "Yes, I want to share something",
-            hint: {
-              text: "After you have submitted your application, your provider may be in touch to discuss the information you shared. If you prefer, you can contact your provider directly."
-            },
             conditional: {
               html: safeguardingHtml
             }

--- a/app/views/application/safeguarding/index.html
+++ b/app/views/application/safeguarding/index.html
@@ -24,7 +24,7 @@
         <li>your professional behaviour, such as by asking for a reference from people you’ve worked with</li>
       </ul> -->
 
-      <p class="govuk-body">Tell providers about any potential safeguarding issues, such as offences, cautions, reprimands and final warnings.</p>
+      <p class="govuk-body">Tell providers about any potential safeguarding issues, such as offences that led to any convictions, cautions, reprimands or final warnings.</p>
 
       <p class="govuk-body">Not all convictions will prevent you from training to be a teacher.</p>
 

--- a/app/views/application/safeguarding/index.html
+++ b/app/views/application/safeguarding/index.html
@@ -24,13 +24,11 @@
         <li>your professional behaviour, such as by asking for a reference from people you’ve worked with</li>
       </ul> -->
 
-      <p class="govuk-body">Tell providers about any potential safeguarding issues, such as offences that led to any convictions, cautions, reprimands or final warnings.</p>
+      <p class="govuk-body">If you receive an offer, training providers will check your references and do an enhanced Disclosure and Barring Service (DBS) check. If you’re outside the UK, they’ll ask you to get a criminal record check from your home country.</p>
 
-      <p class="govuk-body">Not all convictions will prevent you from training to be a teacher.</p>
+      <p class="govuk-body">Not all convictions or police cautions on a criminal record will stop you from training to be a teacher. <a href="https://www.gov.uk/tell-employer-or-college-about-criminal-record">Learn more about when you need to tell someone about your criminal record</a>.</p>
 
       <p class="govuk-body">Talk to the providers you’re applying to for advice on whether any safeguarding issues will affect your application.</p>
-
-      <p class="govuk-body"><a href="https://www.gov.uk/tell-employer-or-college-about-criminal-record">Learn more about when you need to tell someone about your criminal record</a>.</p>
 
       {% set safeguardingHtml %}
         {{ govukCharacterCount({

--- a/app/views/application/submit.html
+++ b/app/views/application/submit.html
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
 
-      <p class="govuk-body">By sending this application to {{ providerText }}, I confirm that the information given is true, complete and accurate.</p>
+      <p class="govuk-body">By sending this application, I confirm that the information given is true, complete and accurate.</p>
 
       <form action="/application/submit" method="post">
         {{ govukButton({

--- a/app/views/application/submit.html
+++ b/app/views/application/submit.html
@@ -14,18 +14,6 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
 
-      {% set dbsCheckHtml %}
-        <p class="govuk-body">As prospective teachers, all candidates must consent to an enhanced DBS check. This will show up any past criminal convictions, both spent and unspent. Some convictions, even if they are spent, will disbar you from teaching.</p>
-        <p class="govuk-body">However, not all past convictions prevent you from training to be a teacher. Talk to your provider about their policy on criminal convictions.</p>
-        <p class="govuk-body"><a href="https://www.gov.uk/exoffenders-and-employment">Learn more about telling an employer about your conviction</a>.</p>
-      {% endset %}
-
-      <p>I understand I will have to undergo an enhanced <a href="https://www.gov.uk/government/organisations/disclosure-and-barring-service">Disclosure and Barring Check</a> as part of my application.</p>
-
-      {{ govukInsetText({
-        html: dbsCheckHtml
-      }) }}
-
       <p class="govuk-body">By sending this application to {{ providerText }}, I confirm that the information given is true, complete and accurate.</p>
 
       <form action="/application/submit" method="post">


### PR DESCRIPTION
We previously removed the 'additional information' question and agreed to merge the information about DBS checks into the question about declaring safeguarding information on the application form.

### Before (question about additional information)
 There is no 'after' as this page is now removed

<img width="457" alt="Screenshot 2023-05-23 at 14 23 01" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/2a842f2c-c759-4af7-999e-b87c26994c30">

### Before (safeguarding question on application form)

<img width="532" alt="Screenshot 2023-05-25 at 09 50 46" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/4ea788ac-ef3d-49b9-841f-cd4d1d45a005">

### After safe guarding question

<img width="683" alt="Screenshot 2023-06-08 at 12 31 14" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/acfa7ffc-5d9a-4519-b510-20d09eee1810">

### After declaration

<img width="691" alt="Screenshot 2023-06-08 at 12 32 24" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/6e660c77-2c93-4ff7-8686-8672c0522ba5">
