### PR TITLE
Update back link on E&D survey.html

### DIFF
--- a/app/views/application/equality-diversity/sex.html
+++ b/app/views/application/equality-diversity/sex.html
@@ -4,7 +4,8 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    href: "/application/equality-diversity"
+    href: "/application",
+    text: "Back to application"
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
The back link navigated to the interstitial page that we decided to remove. Caused some confusion for devs.

### Before:

<img width="565" alt="Screenshot 2023-06-05 at 17 51 35" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/f70da21d-65d4-4a99-9e0a-83b0faeff3fb">

### After:

<img width="709" alt="Screenshot 2023-06-05 at 17 53 29" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/6a39c13c-d9e8-45e0-9890-605ce6c84b03">

