### PR TITLE
Allow courses to be added before all sections completed

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -8,7 +8,7 @@ const router = govukPrototypeKit.requests.setupRouter()
 
 require('./routes/account')(router)
 
-
+require('./routes/details/index')(router)
 require('./routes/details/contact-information')(router)
 require('./routes/details/work-history')(router)
 require('./routes/details/unpaid-experience')(router)

--- a/app/routes/details/index.js
+++ b/app/routes/details/index.js
@@ -1,0 +1,15 @@
+const utils = require('./../../utils')
+
+module.exports = router => {
+
+  router.get('/details', (req, res) => {
+
+    const applications = (req.session.data.applications ? Object.values(req.session.data.applications) : [] )
+    const numberOfApplicationsSubmitted = applications.filter(application => application.submittedAt).length
+
+    res.render('details/index', {
+      numberOfApplicationsSubmitted
+    })
+  })
+
+}

--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -8,56 +8,59 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
 
-    {% if data | allSectionsCompleted %}
 
-      {% if applicationAccepted %}
+    {% if applicationAccepted %}
 
-        <h1 class="govuk-heading-l">Your teacher training course</h1>
+      <h1 class="govuk-heading-l">Your teacher training course</h1>
 
-        <p class="govuk-body">You have accepted an application for {{applicationAccepted.course }} from {{ applicationAccepted.providerName }}.</p>
+      <p class="govuk-body">You have accepted an application for {{applicationAccepted.course }} from {{ applicationAccepted.providerName }}.</p>
 
-        <p class="govuk-body">Your place will be confirmed once they've:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>received your references</li>
-            <li>marked your offer conditions as met</li>
-          </ul>
+      <p class="govuk-body">Your place will be confirmed once they've:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>received your references</li>
+          <li>marked your offer conditions as met</li>
+        </ul>
 
-        <p class="govuk-body">[conditions, SKE, references, etc...]</p>
+      <p class="govuk-body">[conditions, SKE, references, etc...]</p>
 
-        <p class="govuk-body">Option to withdraw</p>
+      <p class="govuk-body">Option to withdraw</p>
+
+    {% else %}
+      {% if numberOfApplicationsLeft > 0 %}
+
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+
+        {% if numberOfApplicationsLeft == 4 %}
+
+          <p class="govuk-body">You can add up to 4 applications at a time.</p>
+
+          {% if not (data | allSectionsCompleted) %}
+            <p class="govuk-body">You will not be able to submit applications until you have completed your details.</p>
+          {% endif %}
+        {% else %}
+          <p class="govuk-body">You can add {{ numberOfApplicationsLeft }} more {{ "applications" if  numberOfApplicationsLeft > 1 else "application" }}.</p>
+        {% endif %}
+
+        <div class="govuk-inset-text">
+          <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
+
+          <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
+
+          <p class="govuk-body"><a href="/application-process">Read about how the application process works.</a></p>
+        </div>
+
+        {{ govukButton({
+          text: "Add application",
+          href: "/applications/start"
+        }) }}
 
       {% else %}
-        {% if numberOfApplicationsLeft > 0 %}
-
         <h1 class="govuk-heading-l">{{ title }}</h1>
+        <p class="govuk-body">You cannot add any more applications because you’re waiting for decisions on 4 others.</p>
+        <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.</p>
+        <p class="govuk-body"><a href="/application-process">Read about how the application process works.</a></p>
 
-          {% if numberOfApplicationsLeft == 4 %}
-
-            <p class="govuk-body">You can add up to 4 applications at a time.</p>
-          {% else %}
-            <p class="govuk-body">You can add {{ numberOfApplicationsLeft }} more {{ "applications" if  numberOfApplicationsLeft > 1 else "application" }}.</p>
-          {% endif %}
-
-          <div class="govuk-inset-text">
-            <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
-
-            <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
-
-            <p class="govuk-body"><a href="/application-process">Read about how the application process works.</a></p>
-          </div>
-
-          {{ govukButton({
-            text: "Add application",
-            href: "/applications/start"
-          }) }}
-
-        {% else %}
-          <h1 class="govuk-heading-l">{{ title }}</h1>
-          <p class="govuk-body">You cannot add any more applications because you’re waiting for decisions on 4 others.</p>
-          <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.</p>
-          <p class="govuk-body"><a href="/application-process">Read about how the application process works.</a></p>
-
-        {% endif %}
+      {% endif %}
 
       {% for id, application in data.applications %}
 
@@ -167,19 +170,7 @@
         }) }}
 
       {% endfor %}
-
-
-      {% endif %}
-
-
-    {% else %}
-
-      <div class="govuk-inset-text">
-        You need to complete <a href="/details" class="govuk-link">your details</a> before you can apply to any courses.
-      </div>
     {% endif %}
-
-
 
   </div>
 </div>

--- a/app/views/applications/review.html
+++ b/app/views/applications/review.html
@@ -59,8 +59,7 @@
 
       })}}
 
-      {% if numberOfApplicationsLeft > 0 %}
-
+      {% if numberOfApplicationsLeft > 0 and (data | allSectionsCompleted) %}
         <form action="/applications/{{ id }}/submit" method="post">
           {{ govukRadios({
             name: "submitNow",
@@ -87,8 +86,15 @@
           })}}
         </form>
       {% else %}
-        <p class="govuk-body">You cannot submit this application because you’re waiting for decisions on 4 others.</p>
-        <p class="govuk-body">If one of your other applications is unsuccessful, or you withdraw it, you will be able to submit this one.</p>
+
+        {% if not (data | allSectionsCompleted) %}
+
+          <p class="govuk-body">You cannot submit this application until you’ve completed your details.</p>
+
+        {% else %}
+          <p class="govuk-body">You cannot submit this application because you’re waiting for decisions on 4 others.</p>
+          <p class="govuk-body">If one of your other applications is unsuccessful, or you withdraw it, you will be able to submit this one.</p>
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -27,12 +27,16 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
 
-      <p class="govuk-body">Complete these sections so that you can start applying to courses. Your details will be shared with the training provider of any course you apply to.</p>
+      <p class="govuk-body">
+        {% if not (data | allSectionsCompleted) %}
+          Complete these sections so that you can start applying to courses.
+        {% endif %}
+        Your details will be shared with the training provider of any course you apply to.
+      </p>
 
-    {% if data | allSectionsCompleted %}
-    {% else %}
-      <p class="govuk-body">You can update your details at any time.</p>
-    {% endif %}
+
+    <p class="govuk-body">You can update your details at any time.</p>
+
       <section class="app-section">
 
         <h2 class="govuk-heading-m">Personal details</h2>


### PR DESCRIPTION
This changes the behaviour of the prototype so that candidates can 'add' a course even if they have not yet completed all sections of their details.  However they cannot yet submit any applications.

This is to enable the existing behaviour where clicking the "Apply" link on Find adds the course to your application regardless of the states of the rest of your application.

## Screenshots

## Before

<img width="771" alt="Screenshot 2023-06-14 at 15 15 22" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/30665/cfabd200-99dc-4be6-9107-304ec73b3450">

## After

<img width="811" alt="Screenshot 2023-06-14 at 15 15 35" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/30665/9efbd2c8-db90-4843-940f-a06159ab2be7">

<img width="849" alt="Screenshot 2023-06-14 at 15 16 05" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/30665/5d2315f7-166d-4c4b-aa11-ba828dd95737">
