### PR TITLE
Version 2 - Personal statement from the task list

### DIFF
--- a/app/routes/admin.js
+++ b/app/routes/admin.js
@@ -115,8 +115,8 @@ module.exports = router => {
     data.unpaidExperienceAdded = 'no'
 
     // Set personal statement
-    data.personalStatement = 'I’ve wanted to become a teacher since being inspired by passionate and brilliant teachers during my school years. There enthusiasm to get the best out of me and to be the best that I can has led me to applying to become a teacher.\n\nI studed English at GCSE and A level and gained not only high academic grades but also a love for the theatre that I want to pass on to the next generation.\n\nWhile volunteering as a teaching assistant I saw the skills needed to be a great teacher one of which is leadership. I am an adept leader and have shown this in several roles. I volunteered in two schools to get experience in different settings and assisted teachers in Key Stages 1 and 2.\n\nI enjoy reading and learning about contemporary ethics and society, considering how I can use this to benefit the students I teach. While in schools I have seen the rewards and challenges presented to teachers and think I have the qualities to make a difference.'
-
+    // data.personalStatement = 'I’ve wanted to become a teacher since being inspired by passionate and brilliant teachers during my school years. There enthusiasm to get the best out of me and to be the best that I can has led me to applying to become a teacher.\n\nI studed English at GCSE and A level and gained not only high academic grades but also a love for the theatre that I want to pass on to the next generation.\n\nWhile volunteering as a teaching assistant I saw the skills needed to be a great teacher one of which is leadership. I am an adept leader and have shown this in several roles. I volunteered in two schools to get experience in different settings and assisted teachers in Key Stages 1 and 2.\n\nI enjoy reading and learning about contemporary ethics and society, considering how I can use this to benefit the students I teach. While in schools I have seen the rewards and challenges presented to teachers and think I have the qualities to make a difference.'
+   
     // Set disability support
     data.additionalSupportNeeded = 'no'
 

--- a/app/routes/admin.js
+++ b/app/routes/admin.js
@@ -162,7 +162,7 @@ module.exports = router => {
       degree: 'true',
       workHistory: 'true',
       unpaidExperience: 'true',
-      personalStatement: 'false',
+      personalStatement: 'true',
       additionalSupport: 'true',
       interviewNeeds: 'true',
       references: 'true',

--- a/app/routes/admin.js
+++ b/app/routes/admin.js
@@ -162,7 +162,7 @@ module.exports = router => {
       degree: 'true',
       workHistory: 'true',
       unpaidExperience: 'true',
-      personalStatement: 'true',
+      personalStatement: 'false',
       additionalSupport: 'true',
       interviewNeeds: 'true',
       references: 'true',

--- a/app/routes/applications.js
+++ b/app/routes/applications.js
@@ -128,6 +128,12 @@ module.exports = router => {
 
   router.get('/applications/:id/personal-statement', (req, res) => {
     const { id } = req.params
+    const mainPersonalStatement=req.session.data.personalStatement
+    let applicationPersonalStatement=req.session.data.applications[id].personalStatement
+    if (mainPersonalStatement && applicationPersonalStatement == undefined){
+      req.session.data.applications[id].personalStatement=mainPersonalStatement
+    }
+
     res.render('applications/personal_statement', {
       id
     })

--- a/app/views/_includes/review/personal-statement.html
+++ b/app/views/_includes/review/personal-statement.html
@@ -1,0 +1,13 @@
+
+<div class="govuk-summary-card govuk-!-margin-bottom-6">
+  <div class="govuk-summary-card__title-wrapper">
+    <a class="govuk-link govuk-!-font-size-19" href="/details/personal-statement">Edit your answer</a>
+  </div>
+  <div class="govuk-summary-card__content">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+        {{ data.personalStatement | govukMarkdown | safe }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/applications/course.html
+++ b/app/views/applications/course.html
@@ -12,6 +12,7 @@
 
 {% block content %}
 
+
   <form action="/applications/{{ id }}/personal-statement" method="post">
 
     {{ govukRadios({

--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -18,7 +18,7 @@
         <p class="govuk-body">You can add up to 4 applications at a time.</p>
 
         {% if not (data | allSectionsCompleted) %}
-          <p class="govuk-body">You will not be able to submit applications until you have completed your details.</p>
+          <p class="govuk-body">You will not be able to submit applications until you have completed <a href="/details">your details</a>.</p>
         {% endif %}
       {% else %}
         <p class="govuk-body">You can add {{ numberOfApplicationsLeft }} more {{ "applications" if  numberOfApplicationsLeft > 1 else "application" }}.</p>

--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -24,6 +24,10 @@
         <p class="govuk-body">You can add {{ numberOfApplicationsLeft }} more {{ "applications" if  numberOfApplicationsLeft > 1 else "application" }}.</p>
       {% endif %}
 
+      {% if (applicationsSubmitted | length == 0) %}
+        <p class="govuk-body">You’ll be asked to write a personal statement of 500 words before you submit.</p>
+      {% endif %}
+
       <div class="govuk-inset-text">
          <p class="govuk-body">Training providers offer places on courses throughout the year.</p>
 

--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -25,7 +25,7 @@
       {% endif %}
 
       {% if (applicationsSubmitted | length == 0) %}
-        <p class="govuk-body">You’ll be asked to write a personal statement of 500 words before you submit.</p>
+        <p class="govuk-body">You’ll be asked to edit your personal statement for each application before you submit.</p>
       {% endif %}
 
       <div class="govuk-inset-text">

--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -25,7 +25,7 @@
       {% endif %}
 
       {% if (applicationsSubmitted | length == 0) %}
-        <p class="govuk-body">You’ll be asked to edit your personal statement for each application before you submit.</p>
+        <p class="govuk-body">You'll be able to edit your personal statement for each application if you want to.</p>
       {% endif %}
 
       <div class="govuk-inset-text">

--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -25,9 +25,9 @@
       {% endif %}
 
       <div class="govuk-inset-text">
-        <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
+         <p class="govuk-body">Training providers offer places on courses throughout the year.</p>
 
-        <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
+         <p class="govuk-body">Courses can fill up quickly, you should apply as soon as you’re ready.</p>
 
         <p class="govuk-body"><a href="/application-process">Read about how the application process works.</a></p>
       </div>

--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -31,7 +31,7 @@
       <div class="govuk-inset-text">
          <p class="govuk-body">Training providers offer places on courses throughout the year.</p>
 
-         <p class="govuk-body">Courses can fill up quickly, you should apply as soon as you’re ready.</p>
+         <p class="govuk-body">Courses can fill up quickly so apply as soon as you can.</p>
 
         <p class="govuk-body"><a href="/application-process">Read about how the application process works.</a></p>
       </div>

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -22,7 +22,7 @@
 
         <div class="govuk-inset-text">
           <p class="govuk-body">We've copied your statement from your details. You can edit it further if you want to.</p>
-          <p class="govuk-body">Any changes you make will be saved for this application and on your statement in your details.</p>
+          <p class="govuk-body">Any changes you make will be saved for this application only.</p>
         </div>
           <p class="govuk-body">You should write 500 words for your personal statement.</p>
           <p class="govuk-body">Here are some examples you could add (they are just a guide, you do not need to write about all of them):</p>

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -51,7 +51,6 @@
               {% else %}
               <li>your interest in {{ data.applications[id].course | replace(courseCodeRegex, "") | lower }}</li>
               {% endif %}
-            <li>your reasons for wanting to train to be a teacher</li>
             <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
           </ul>
 

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -25,7 +25,7 @@
           <p class="govuk-body">Any changes you make will be saved for this application only.</p>
         </div>
           <p class="govuk-body">You should write 500 words for your personal statement.</p>
-          <p class="govuk-body">Here are some examples you could add (they are just a guide, you do not need to write about all of them):</p>
+          <p class="govuk-body">You could include details about:</p>
 
           <ul class="govuk-list govuk-list--bullet">
             <li>why you're applying to {{ data.applications[id].providerName }}</li>

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -15,26 +15,47 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
 
-
+    
       {% set guidanceHtml %}
-      <div class="govuk-inset-text">
-        <p class="govuk-body">We've copied your statement from your details. You can edit it further if you want to.</p>
-        <p class="govuk-body">Any changes you make will be saved for this application and on your statement in your details.</p>
-      </div>
-        <p class="govuk-body">You should write 500 words for your personal statement.</p>
-        <p class="govuk-body">Here are some examples you could add (they are just a guide, you do not need to write about all of them):</p>
 
-        <ul class="govuk-list govuk-list--bullet">
-          <li>why you're applying to {{ data.applications[id].providerName }}</li>
+        {% if data.completed.personalStatement %}
 
-          {% set primaryRegex = r/^Primary\s.*/g %}
-          {% set courseCodeRegex = r/\([^)]+\)/ %}
-          {% if primaryRegex.test(data.applications[id].course) %}
-          {% else %}
-            <li>your interest in {{ data.applications[id].course | replace(courseCodeRegex, "") | lower }}</li>
-          {% endif %}
-        </ul>
+        <div class="govuk-inset-text">
+          <p class="govuk-body">We've copied your statement from your details. You can edit it further if you want to.</p>
+          <p class="govuk-body">Any changes you make will be saved for this application and on your statement in your details.</p>
+        </div>
+          <p class="govuk-body">You should write 500 words for your personal statement.</p>
+          <p class="govuk-body">Here are some examples you could add (they are just a guide, you do not need to write about all of them):</p>
 
+          <ul class="govuk-list govuk-list--bullet">
+            <li>why you're applying to {{ data.applications[id].providerName }}</li>
+              {% set primaryRegex = r/^Primary\s.*/g %}
+              {% set courseCodeRegex = r/\([^)]+\)/ %}
+              {% if primaryRegex.test(data.applications[id].course) %}
+              {% else %}
+              <li>your interest in {{ data.applications[id].course | replace(courseCodeRegex, "") | lower }}</li>
+              {% endif %}
+          </ul>
+
+        {% else %}
+          <p class="govuk-body">You should write 500 words for your personal statement.</p>
+          <p class="govuk-body">You'll be able edit your statement further for each application you submit.</p>
+          <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li>skills you have that are relevant to teaching</li>
+            <li>any experience of working with young people</li>
+             {% set primaryRegex = r/^Primary\s.*/g %}
+              {% set courseCodeRegex = r/\([^)]+\)/ %}
+              {% if primaryRegex.test(data.applications[id].course) %}
+              {% else %}
+              <li>your interest in {{ data.applications[id].course | replace(courseCodeRegex, "") | lower }}</li>
+              {% endif %}
+            <li>your reasons for wanting to train to be a teacher</li>
+            <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
+          </ul>
+
+        {% endif %}
       {% endset %}
 
       {{ guidanceHtml | safe }}

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -17,12 +17,15 @@
 
 
       {% set guidanceHtml %}
-        <p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
-        <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">We've copied your statement from your details. You can edit it further if you want to.</p>
+        <p class="govuk-body">Any changes you make will be saved for this application and on your statement in your details.</p>
+      </div>
+        <p class="govuk-body">You should write 500 words for your personal statement.</p>
+        <p class="govuk-body">Here are some examples you could add (they are just a guide, you do not need to write about all of them):</p>
 
         <ul class="govuk-list govuk-list--bullet">
-          <li>skills you have that are relevant to teaching</li>
-          <li>any experience of working with young people</li>
+          <li>why you're applying to {{ data.applications[id].providerName }}</li>
 
           {% set primaryRegex = r/^Primary\s.*/g %}
           {% set courseCodeRegex = r/\([^)]+\)/ %}
@@ -30,9 +33,6 @@
           {% else %}
             <li>your interest in {{ data.applications[id].course | replace(courseCodeRegex, "") | lower }}</li>
           {% endif %}
-          <li>your understanding of why teaching is important</li>
-          <li>your reasons for wanting to train to be a teacher</li>
-          <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
         </ul>
 
       {% endset %}

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -41,15 +41,15 @@
 
       <form action="/applications/{{ id }}/review" method="post">
         {{ govukCharacterCount({
-          name: "applications[" + id + "][personalStatement]",
-          value: data.applications[id].personalStatement,
+          name: "personalStatement",
+          value: data.personalStatement,
           id: "personal-statement",
           label: {
             text: "Your personal statement",
             classes: "govuk-label--m govuk-!-margin-top-6"
           },
           rows: 15,
-          maxwords: 1000
+          maxwords: 500
         }) }}
 
         {{ govukButton({

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -57,6 +57,10 @@
         {% endif %}
       {% endset %}
 
+      {% set hint %}
+        You can finish your statement later if you're not ready to write it now.
+      {% endset %}
+
       {{ guidanceHtml | safe }}
 
       <form action="/applications/{{ id }}/review" method="post">
@@ -67,6 +71,9 @@
           label: {
             text: "Your personal statement",
             classes: "govuk-label--m govuk-!-margin-top-6"
+          },
+            hint: {
+            text: hint
           },
           rows: 15,
           maxwords: 500

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -18,7 +18,7 @@
     
       {% set guidanceHtml %}
 
-        {% if data.completed.personalStatement %}
+        {% if data.personalStatement and data.personalStatement == data.applications[id].personalStatement %}
 
         <div class="govuk-inset-text">
           <p class="govuk-body">We've copied your statement from your details. You can edit it further if you want to.</p>
@@ -65,8 +65,8 @@
 
       <form action="/applications/{{ id }}/review" method="post">
         {{ govukCharacterCount({
-          name: "personalStatement",
-          value: data.personalStatement,
+          name: "applications[" + id + "][personalStatement]",
+          value: data.applications[id].personalStatement,
           id: "personal-statement",
           label: {
             text: "Your personal statement",

--- a/app/views/applications/personal_statement.html
+++ b/app/views/applications/personal_statement.html
@@ -39,7 +39,7 @@
 
         {% else %}
           <p class="govuk-body">You should write 500 words for your personal statement.</p>
-          <p class="govuk-body">You'll be able edit your statement further for each application you submit.</p>
+          <p class="govuk-body">You'll be able edit your statement again for each application you submit.</p>
           <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
 
           <ul class="govuk-list govuk-list--bullet">

--- a/app/views/applications/review.html
+++ b/app/views/applications/review.html
@@ -26,7 +26,7 @@
               text: "Course"
             },
             value: {
-              html: application.course + "<br>PGCE<br>Full time"
+              html: application.course + "<br>PGCE"
             },
             actions: {
               items: [
@@ -35,29 +35,52 @@
                   href: "/applications/" + id + "/course"
                 }
               ]
-            }
-          }
-          ,
+            } if not application.submittedAt
+          },
           {
             key: {
-              text: "Personal statement"
+              text: "Study mode"
             },
             value: {
-              text: data.personalStatement
+              html: "Full time"
             },
             actions: {
               items: [
                 {
                   text: "Change",
-                  href: "/applications/" + id + "/personal-statement"
-                }
-              ]
+                  href: "/applications/" + id + "/course"
             }
-          }
-
-        ]
+          ]
+        }
+      }
+    
+    ]
 
       })}}
+
+<div class="govuk-summary-card govuk-!-margin-bottom-6">
+  <div class="govuk-summary-card__title-wrapper">
+    <h2 class="govuk-summary-card__title">Personal statement</h2>
+    {% if data.personalStatement %}
+      <ul class="govuk-summary-card__actions">
+        <li class="govuk-summary-card__action"> <a class="govuk-link govuk-!-font-weight-regular" href="/applications/{{ id }}/personal-statement">Edit your personal statement</a>
+          </a>
+        </li>
+      </ul>
+    {% endif %}
+  </div>
+  <div class="govuk-summary-card__content">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+        {% if data.personalStatement %}
+          {{ data.personalStatement | govukMarkdown | safe }}
+        {% else %}
+          <a class="govuk-link govuk-!-font-size-19" href="/applications/{{ id }}/personal-statement">Add your personal statement</a>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
 
       {% if numberOfApplicationsLeft > 0 and (data | allSectionsCompleted) %}
         <form action="/applications/{{ id }}/submit" method="post">

--- a/app/views/applications/review.html
+++ b/app/views/applications/review.html
@@ -109,11 +109,14 @@
         </form>
       {% else %}
 
-        {% if not (data | allSectionsCompleted) %}
+      {% if not data.personalStatement %}
+          <p class="govuk-body">You cannot submit this application – it will be saved as a draft until you’ve written your personal statement.</p>
+      
+      {% elseif not (data | allSectionsCompleted) %}
 
-          <p class="govuk-body">You cannot submit this application until you’ve completed <a href="/details">your details</a>.</p>
+          <p class="govuk-body">You cannot submit this application – it will be saved as a draft until you’ve completed <a href="/details">your details</a>.</p>
 
-        {% else %}
+      {% else %}
           <p class="govuk-body">You cannot submit this application because you’re waiting for decisions on 4 others.</p>
           <p class="govuk-body">If one of your other applications is unsuccessful, or you withdraw it, you will be able to submit this one.</p>
         {% endif %}

--- a/app/views/applications/review.html
+++ b/app/views/applications/review.html
@@ -61,7 +61,7 @@
 <div class="govuk-summary-card govuk-!-margin-bottom-6">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">Personal statement</h2>
-    {% if data.personalStatement %}
+    {% if data.applications[id].personalStatement %}
       <ul class="govuk-summary-card__actions">
         <li class="govuk-summary-card__action"> <a class="govuk-link govuk-!-font-weight-regular" href="/applications/{{ id }}/personal-statement">Edit your personal statement</a>
         </li>
@@ -71,8 +71,8 @@
   <div class="govuk-summary-card__content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
-        {% if data.personalStatement %}
-          {{ data.personalStatement | govukMarkdown | safe }}
+        {% if data.applications[id].personalStatement %}
+          {{ data.applications[id].personalStatement | govukMarkdown | safe }}
         {% else %}
           <a class="govuk-link govuk-!-font-size-19" href="/applications/{{ id }}/personal-statement">Add your personal statement</a>
         {% endif %}
@@ -81,7 +81,7 @@
   </div>
 </div>
 
-      {% if numberOfApplicationsLeft > 0 and (data | allSectionsCompleted) %}
+      {% if numberOfApplicationsLeft > 0 and (data | allSectionsCompleted) and data.applications[id].personalStatement %}
         <form action="/applications/{{ id }}/submit" method="post">
           {{ govukRadios({
             name: "submitNow",
@@ -109,7 +109,7 @@
         </form>
       {% else %}
 
-      {% if not data.personalStatement %}
+      {% if not data.applications[id].personalStatement %}
           <p class="govuk-body">You cannot submit this application – it will be saved as a draft until you’ve written your personal statement.</p>
       
       {% elseif not (data | allSectionsCompleted) %}

--- a/app/views/applications/review.html
+++ b/app/views/applications/review.html
@@ -43,7 +43,7 @@
               text: "Personal statement"
             },
             value: {
-              text: application.personalStatement
+              text: data.personalStatement
             },
             actions: {
               items: [

--- a/app/views/applications/review.html
+++ b/app/views/applications/review.html
@@ -89,7 +89,7 @@
 
         {% if not (data | allSectionsCompleted) %}
 
-          <p class="govuk-body">You cannot submit this application until you’ve completed your details.</p>
+          <p class="govuk-body">You cannot submit this application until you’ve completed <a href="/details">your details</a>.</p>
 
         {% else %}
           <p class="govuk-body">You cannot submit this application because you’re waiting for decisions on 4 others.</p>

--- a/app/views/applications/review.html
+++ b/app/views/applications/review.html
@@ -64,7 +64,6 @@
     {% if data.personalStatement %}
       <ul class="govuk-summary-card__actions">
         <li class="govuk-summary-card__action"> <a class="govuk-link govuk-!-font-weight-regular" href="/applications/{{ id }}/personal-statement">Edit your personal statement</a>
-          </a>
         </li>
       </ul>
     {% endif %}

--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -189,6 +189,23 @@
           }]
         }) }}
       </section>
+
+      <section class="app-section">
+        <h2 class="govuk-heading-m">Personal statement</h2>
+        {{ govukTaskList({
+          items: [{
+            title: { text: "Your personal statement" },
+            href: "#",
+            id: "personal-statement",
+            status: {
+              classes: tagClassesForSection(completed=data.completed.equalityMonitoring == 'true'),
+              text: tagTextForSection(completed=data.completed.equalityMonitoring == 'true')
+            }
+          }]
+        }) }}
+      </section>
+
+
    </div>
 
     <div class="govuk-grid-column-one-third">

--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -183,8 +183,8 @@
             href: "/details/equality-diversity/sex",
             id: "equality",
             status: {
-              classes: tagClassesForSection(completed=data.completed.equalityAndDiversity == 'true'),
-              text: tagTextForSection(completed=data.completed.equalityAndDiversity == 'true')
+              classes: tagClassesForSection(completed=data.completed.equalityMonitoring == 'true'),
+              text: tagTextForSection(completed=data.completed.equalityMonitoring == 'true')
             }
           }]
         }) }}

--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -195,7 +195,7 @@
         {{ govukTaskList({
           items: [{
             title: { text: "Your personal statement" },
-            href: "/details/personal-statement/personal_statement",
+            href: "/details/personal-statement/index",
             id: "personal-statement",
             status: {
               classes: tagClassesForSection(completed=data.completed.equalityMonitoring == 'true'),

--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -195,7 +195,7 @@
         {{ govukTaskList({
           items: [{
             title: { text: "Your personal statement" },
-            href: "/details/personal-statement/index",
+            href: "/details/personal-statement",
             id: "personal-statement",
             status: {
               classes: tagClassesForSection(completed=data.completed.personalStatement == 'true'),

--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -195,7 +195,7 @@
         {{ govukTaskList({
           items: [{
             title: { text: "Your personal statement" },
-            href: "#",
+            href: "/details/personal-statement/personal_statement",
             id: "personal-statement",
             status: {
               classes: tagClassesForSection(completed=data.completed.equalityMonitoring == 'true'),

--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -183,8 +183,8 @@
             href: "/details/equality-diversity/sex",
             id: "equality",
             status: {
-              classes: tagClassesForSection(completed=data.completed.equalityMonitoring == 'true'),
-              text: tagTextForSection(completed=data.completed.equalityMonitoring == 'true')
+              classes: tagClassesForSection(completed=data.completed.equalityAndDiversity == 'true'),
+              text: tagTextForSection(completed=data.completed.equalityAndDiversity == 'true')
             }
           }]
         }) }}
@@ -198,8 +198,8 @@
             href: "/details/personal-statement/index",
             id: "personal-statement",
             status: {
-              classes: tagClassesForSection(completed=data.completed.equalityMonitoring == 'true'),
-              text: tagTextForSection(completed=data.completed.equalityMonitoring == 'true')
+              classes: tagClassesForSection(completed=data.completed.personalStatement == 'true'),
+              text: tagTextForSection(completed=data.completed.personalStatement == 'true')
             }
           }]
         }) }}

--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -29,7 +29,7 @@
 
       <p class="govuk-body">
         {% if not (data | allSectionsCompleted) %}
-          Complete these sections so that you can start applying to courses.
+          Complete these sections so that you can start <a href="/applications">applying to courses</a>.
         {% endif %}
         Your details will be shared with the training provider of any course you apply to.
       </p>

--- a/app/views/details/personal-statement/index.html
+++ b/app/views/details/personal-statement/index.html
@@ -18,12 +18,13 @@
 
       {% set guidanceHtml %}
         <p class="govuk-body">You should write 500 words for your personal statement.</p>
+        <p class="govuk-body">You'll be able edit your statement further for each application you submit.</p>
         <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>skills you have that are relevant to teaching</li>
           <li>any experience of working with young people</li>
-          <li>your understanding of why teaching is important</li>
+          <li>your interest in the subject you want to apply for</li>
           <li>your reasons for wanting to train to be a teacher</li>
           <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
         </ul>

--- a/app/views/details/personal-statement/index.html
+++ b/app/views/details/personal-statement/index.html
@@ -18,7 +18,7 @@
 
       {% set guidanceHtml %}
         <p class="govuk-body">You should write 500 words for your personal statement.</p>
-        <p class="govuk-body">You'll be able edit your statement further for each application you submit.</p>
+        <p class="govuk-body">You'll be able edit your statement again for each application you submit.</p>
         <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
 
         <ul class="govuk-list govuk-list--bullet">

--- a/app/views/details/personal-statement/index.html
+++ b/app/views/details/personal-statement/index.html
@@ -25,7 +25,6 @@
           <li>skills you have that are relevant to teaching</li>
           <li>any experience of working with young people</li>
           <li>your interest in the subject you want to apply for</li>
-          <li>your reasons for wanting to train to be a teacher</li>
           <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
         </ul>
 

--- a/app/views/details/personal-statement/index.html
+++ b/app/views/details/personal-statement/index.html
@@ -1,12 +1,12 @@
 {% extends "layouts/main.html" %}
 
-{% set primaryNavId = "applications" %}
+{% set primaryNavId = "details" %}
 {% set title = "Personal statement" %}
 
 {% block beforeContent %}
   {{ govukBackLink({
-    href: "/applications/" + id + "/course",
-    text: "Back"
+    href: "/details",
+    text: "Back to your details"
   }) }}
 {% endblock %}
 
@@ -23,13 +23,6 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>skills you have that are relevant to teaching</li>
           <li>any experience of working with young people</li>
-
-          {% set primaryRegex = r/^Primary\s.*/g %}
-          {% set courseCodeRegex = r/\([^)]+\)/ %}
-          {% if primaryRegex.test(data.applications[id].course) %}
-          {% else %}
-            <li>your interest in {{ data.applications[id].course | replace(courseCodeRegex, "") | lower }}</li>
-          {% endif %}
           <li>your understanding of why teaching is important</li>
           <li>your reasons for wanting to train to be a teacher</li>
           <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>

--- a/app/views/details/personal-statement/index.html
+++ b/app/views/details/personal-statement/index.html
@@ -19,12 +19,12 @@
       {% set guidanceHtml %}
         <p class="govuk-body">You should write 500 words for your personal statement.</p>
         <p class="govuk-body">You'll be able edit your statement again for each application you submit.</p>
-        <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
+        <p class="govuk-body">You could include details about:</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>skills you have that are relevant to teaching</li>
           <li>any experience of working with young people</li>
-          <li>your interest in the subject you want to apply for</li>
+          <li>your interest in the subject or age group you want to teach</li>
           <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
         </ul>
 

--- a/app/views/details/personal-statement/index.html
+++ b/app/views/details/personal-statement/index.html
@@ -17,7 +17,7 @@
 
 
       {% set guidanceHtml %}
-        <p class="govuk-body">You should write up to 500 words for your personal statement.</p>
+        <p class="govuk-body">You should write between 500 and 750 words for your personal statement.</p>
         <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
 
         <ul class="govuk-list govuk-list--bullet">

--- a/app/views/details/personal-statement/index.html
+++ b/app/views/details/personal-statement/index.html
@@ -17,7 +17,7 @@
 
 
       {% set guidanceHtml %}
-        <p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
+        <p class="govuk-body">You should write up to 500 words for your personal statement.</p>
         <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
 
         <ul class="govuk-list govuk-list--bullet">
@@ -32,17 +32,17 @@
 
       {{ guidanceHtml | safe }}
 
-      <form action="/applications/{{ id }}/review" method="post">
+      <form action="/details/personal-statement/review" method="post">
         {{ govukCharacterCount({
-          name: "applications[" + id + "][personalStatement]",
-          value: data.applications[id].personalStatement,
+          name: "personalStatement",
+          value: data.personalStatement,
           id: "personal-statement",
           label: {
             text: "Your personal statement",
             classes: "govuk-label--m govuk-!-margin-top-6"
           },
           rows: 15,
-          maxwords: 1000
+          maxwords: 500
         }) }}
 
         {{ govukButton({

--- a/app/views/details/personal-statement/index.html
+++ b/app/views/details/personal-statement/index.html
@@ -17,7 +17,7 @@
 
 
       {% set guidanceHtml %}
-        <p class="govuk-body">You should write between 500 and 750 words for your personal statement.</p>
+        <p class="govuk-body">You should write 500 words for your personal statement.</p>
         <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
 
         <ul class="govuk-list govuk-list--bullet">

--- a/app/views/details/personal-statement/personal_statement.html
+++ b/app/views/details/personal-statement/personal_statement.html
@@ -1,0 +1,61 @@
+{% extends "layouts/main.html" %}
+
+{% set primaryNavId = "applications" %}
+{% set title = "Personal statement" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "/applications/" + id + "/course",
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+
+
+      {% set guidanceHtml %}
+        <p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
+        <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>skills you have that are relevant to teaching</li>
+          <li>any experience of working with young people</li>
+
+          {% set primaryRegex = r/^Primary\s.*/g %}
+          {% set courseCodeRegex = r/\([^)]+\)/ %}
+          {% if primaryRegex.test(data.applications[id].course) %}
+          {% else %}
+            <li>your interest in {{ data.applications[id].course | replace(courseCodeRegex, "") | lower }}</li>
+          {% endif %}
+          <li>your understanding of why teaching is important</li>
+          <li>your reasons for wanting to train to be a teacher</li>
+          <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
+        </ul>
+
+      {% endset %}
+
+      {{ guidanceHtml | safe }}
+
+      <form action="/applications/{{ id }}/review" method="post">
+        {{ govukCharacterCount({
+          name: "applications[" + id + "][personalStatement]",
+          value: data.applications[id].personalStatement,
+          id: "personal-statement",
+          label: {
+            text: "Your personal statement",
+            classes: "govuk-label--m govuk-!-margin-top-6"
+          },
+          rows: 15,
+          maxwords: 1000
+        }) }}
+
+        {{ govukButton({
+          text: "Save and continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/details/personal-statement/review.html
+++ b/app/views/details/personal-statement/review.html
@@ -1,0 +1,46 @@
+{% extends "layouts/main.html" %}
+
+{% set primaryNavId = "details" %}
+
+{% set applicationPath = "/details/" %}
+{% set formaction = applicationPath %}
+{% set referrer = applicationPath + "/personal-statement/review" %}
+{% set title = "Personal statement" %}
+{% set canAmend = true %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: applicationPath,
+    text: "Back to your details"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ title }}</h1>
+  {% include "_includes/review/personal-statement.html" %}
+
+  <form action="/details" method="post">
+    {{ govukRadios({
+      name: "completed[personalStatement]",
+      value: data.completed.personalStatement,
+      fieldset: {
+        classes: "govuk-!-width-two-thirds",
+        legend: {
+          text: "Have you completed this section?",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [{
+        value: "true",
+        text: "Yes, I’ve completed this section"
+      }, {
+        value: "false",
+        text: "No, I’ll come back to it later"
+      }]
+    }) }}
+
+    {{ govukButton({
+      text: "Continue"
+    }) }}
+  </form>
+{% endblock %}


### PR DESCRIPTION
In this option for the personal statement, we will have the statement in the 'Your details' tab at the bottom of the task list. It's at the bottom because all the other information is more factual about the candidate, whereas the statement is more to do with the application.

I've mocked up 2 basic flows, but further considerations for this version I've [mapped out in Lucid](https://lucid.app/lucidspark/ecc3570a-b51b-4542-a006-4fe83ad82672/edit?view_items=l~k9BPCsUq55&invitationId=inv_b74a2045-8811-49f3-a4cf-1dc6334349d1) (mainly for my own sanity).

Candidates can choose to fill this out as part of the task list.

## Screenshots

### Personal statement at the bottom of the task list

<img width="552" alt="Screenshot 2023-06-21 at 15 18 26" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/9586bfb4-3bbc-4ff9-acf6-0a76500dbcac">

### Personal statement question, with an extra line about telling the candidate they will be able to edit it again for each application.

<img width="580" alt="Screenshot 2023-06-21 at 15 19 42" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/e8882cd6-f624-420e-bc75-97e6d47ff951">

### The review page from the task list follows the same pattern we currently have.

<img width="823" alt="Screenshot 2023-06-21 at 15 21 14" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/45b72677-131f-49e6-8753-425224050e2e">

### Adding an application

When the candidate has completed their 'Your details' and starts adding an application, their personal statement is copied over. We show slightly different text to tell them what's happened. We also change the bullet points to help guide them/think about how they could tailor it.

<img width="554" alt="Screenshot 2023-06-21 at 15 22 21" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/5e017705-b356-49ec-861f-0aeeadc098c9">

### Review page stays the same as we have now

<img width="609" alt="Screenshot 2023-06-21 at 16 05 38" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/8128cfce-9c1e-4af7-8fe3-a9391a71a426">

### Writing a personal statement from the 'Your applications' tab (the course flow first)

Another route, is the user can add an application as their first step. This means they will write their personal statement first from the 'Your application' tab and we need to copy it back to the task list.

### We show the normal personal statement guidance if this is the first time they are writing the statement.

<img width="571" alt="Screenshot 2023-06-21 at 16 08 29" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/b4e060d0-8e4c-4935-a9f1-44edb40b9321">

### The review page also stays the same. But we show the user that they need to complete your details to submit the application.

<img width="626" alt="Screenshot 2023-06-21 at 16 08 52" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/dd302a3a-9147-49da-b8b3-7b4999750520">

### When they navigate back to the 'Your details' tab to complete the task list, we would copy what they wrote in their personal statement on their draft application to the personal statement on the task list.

<img width="599" alt="Screenshot 2023-06-21 at 16 09 08" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/e3d4f602-4071-4dbb-a97e-a93606d221f9">

### The review page would stay the same

<img width="807" alt="Screenshot 2023-06-21 at 16 09 16" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/a48c77b4-3f1f-4dd5-94aa-13960ab9e7b1">


