### PR TITLE
Fixed 'withdrawal' and 'remove' link on application page

### DIFF
--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -115,7 +115,7 @@
             },
             {
               href: "/applications/" + id + "/delete",
-              text: ("Withdraw" if application.status === "Awaiting decision" or application.status === "Inactive"  else "Remove"),
+              text: ("Withdraw" if application.status === "Awaiting decision" or application.status === "Inactive"  or application.status === "Offer received" else "Remove"),
               visuallyHiddenText: "from " + application.providerName,
               classes: ""
             }


### PR DESCRIPTION
I noticed on the prototype when an application is in "offer received' status, the link says 'Remove', but it should say 'Withdraw"
Small fix to update that.

**BEFORE:**
<img width="779" alt="Screenshot 2023-07-07 at 09 47 13" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/f6fd1132-367b-4def-8da9-bc1fd7c82aec">

**AFTER:**
<img width="758" alt="Screenshot 2023-07-07 at 09 42 00" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/7408900e-368c-4b1e-8c69-33588f4609fe">
