### PR TITLE
Match content on prototype to production

### DIFF
--- a/app/views/accepted/index.html
+++ b/app/views/accepted/index.html
@@ -1,6 +1,6 @@
 {% extends "layouts/main.html" %}
 
-{% set title = "Your training course" %}
+{% set title = "Your offer" %}
 {% set primaryNavId = "accepted" %}
 
 {% block content %}
@@ -8,7 +8,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">{{ title | safe }}</h1>
+      <h1 class="govuk-heading-xl">{{ title | safe }} for {{ acceptedApplication.course }}</h1>
 
     </div>
   </div>

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -25,7 +25,7 @@
         items: [
           {
             href: "/accepted",
-            text: "Your training course",
+            text: "Your offer",
             active: primaryNavId == "accepted"
           }
         ],


### PR DESCRIPTION
We designed this page immediately on production but did not update the prototype. Small change to match the H1 and navigation tab content so people don't get confused.

This page shows when a candidate has accepted an offer, but if still waiting for their conditions to be met.

**BEFORE:**

<img width="927" alt="Screenshot 2023-07-07 at 12 12 50" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/7bb8593c-339b-4f66-b6d4-29ef5e9ef93b">

**AFTER:**

<img width="911" alt="Screenshot 2023-07-07 at 12 12 18" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/a683d35a-2991-45b1-9ea1-2834df050bc0">

