### PR TITLE
Remove links from footer

### DIFF
--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -72,7 +72,7 @@
       items: [
         {
           href: "/manage-prototype",
-          text: "Manage prototype"
+          text: "Manage this prototype"
         },
         {
           href: "/manage-prototype/clear-data",
@@ -89,18 +89,6 @@
         {
           href: "/admin/add-application",
           text: "Add application"
-        },
-        {
-          href: "/admin/receive-offer",
-          text: "Receive an offer"
-        },
-        {
-          href: "/admin/receive-rejection",
-          text: "Unsuccessful"
-        },
-        {
-          href: "/admin/receive-inactive",
-          text: "Inactive application"
         }
       ]
     }


### PR DESCRIPTION
Small fix to remove redundant link from the footer of the prototype as it was confusing people.

Also changed content from 'Manage prototype' to 'Manage this prototype' because it sounded like we're talking about the Manage service.

**Before:**
<img width="784" alt="Screenshot 2023-07-31 at 16 31 18" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/0d55477e-e28e-4256-8cc4-aab92b2ee640">

**After:**

<img width="644" alt="Screenshot 2023-07-31 at 16 31 07" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/6a7bb7cb-3b13-420b-9ff2-a60ab8c90690">
