### PR TITLE
Updated content to remove mention of adding other courses

### DIFF
--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -39,7 +39,7 @@
 
     {% else %}
       <h1 class="govuk-heading-l">{{ title }}</h1>
-      <p class="govuk-body">You cannot add any more applications because you’re waiting for decisions on 4 others.</p>
+      <p class="govuk-body">You cannot add any more applications.</p>
       <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.</p>
       <p class="govuk-body"><a href="/application-process">Read about how the application process works.</a></p>
 

--- a/app/views/applications/provider-already-selected.html
+++ b/app/views/applications/provider-already-selected.html
@@ -19,7 +19,7 @@
       <p class="govuk-body">You can:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>add other courses offered by {{ data.applications[id].providerName }} to your <a href="#">existing application</a></li>
+        <li>apply to a <a href="/applications/{{ id }}/course">different course</a> offered by {{ data.applications[id].providerName }}</li>
         <li>apply to a <a href="/applications/{{ id }}/provider">different training provider</a></li>
       </ul>
 


### PR DESCRIPTION
We removed a feature allowing candidates to add multiple courses to the same application to the same provider.
We decided this was not MVP for continuous applications.

I've edited to content to reflect this so it does not confuse the devs when building (the first bullet point in the images below)

I've also removed mention of draft applications when a user has applied to 4 courses and cannot apply any more.

**Before:**
<img width="719" alt="Screenshot 2023-07-31 at 17 43 57" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/c0ad65bd-30e4-4669-95f8-3201dc86ef3c">

**After:**
<img width="717" alt="Screenshot 2023-07-31 at 17 38 19" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/10f6ca3e-b868-4e56-9545-8936f1ce6d38">


