### PR TITLE
Adding a confirmation statement before submitting an application.

### DIFF
--- a/app/views/applications/review.html
+++ b/app/views/applications/review.html
@@ -94,7 +94,10 @@
             items: [
               {
                 value: "yes",
-                text: "Yes, submit it now"
+                text: "Yes, submit it now",
+                hint: {
+                  text: "By submitting this application, you confirm that your details are true, complete and accurate."
+                  }
               },
               {
                 value: "no",


### PR DESCRIPTION
As part of our discussions on Tue 8/8 on building the submission journey to continuous applications, we discussed have some content before a candidate submits to confirm their info in correct.

We used to have this in the service, but somehwere along the line it was removed from the prototype. I've added it back for Tomas to build.

<img width="833" alt="Screenshot 2023-08-09 at 09 59 00" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/755f2840-711d-4ddc-b1b4-998a3ed91f59">
