### PR TITLE
added skip link to go straight to prototype

### DIFF
--- a/app/views/account/check-email.html
+++ b/app/views/account/check-email.html
@@ -7,10 +7,12 @@
 {% block content %}
   <h1 class="govuk-heading-l">{{ title }}</h1>
   {% if action == "sign-in"%}
+    <p><a href="/details">Go to prototype</a>.</p>
     <p><a class="app-hidden-link" href="/details">We’ve sent a sign in link to {{ data.account.email or 'your-email@domain.com' }}</a>.</p>
 
     <p>If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <a href="/account/sign-in">try again</a>.</p>
   {% else %}
+    <p><a href="/details">Go to prototype</a>.</p>
     <p><a class="app-hidden-link" href="/details">We’ve sent an email to {{ data.account.email or 'your-email@domain.com' }}</a>.</p>
     <p>Click on the link to confirm your {{ "new " if action == "change-email-address" }}address and return to this service.</p>
     <p>If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <a href="/account/create-account">try again</a>.</p>

--- a/app/views/account/index.html
+++ b/app/views/account/index.html
@@ -12,6 +12,7 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="/account" method="post" novalidate="true">
         <h1 class="govuk-heading-l">Create an account or sign in</h1>
+        <p><a href="/details">Skip sign in pages and go to prototype</a></p>
 
         {% set signinHtml %}
           {{ govukInput({

--- a/app/views/account/index.html
+++ b/app/views/account/index.html
@@ -12,7 +12,7 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="/account" method="post" novalidate="true">
         <h1 class="govuk-heading-l">Create an account or sign in</h1>
-        <p><a href="/details">Skip sign in pages and go to prototype</a></p>
+        <p><a href="/details">Skip sign in pages and go to prototype</a>.</p>
 
         {% set signinHtml %}
           {{ govukInput({


### PR DESCRIPTION
I've been contacted by a few people who get confused when signing in to the Apply prototype. They think they have to sign in, but they do not. They also miss the secret link on the final sign in page.

I've added a link to skip the sign in screens to make it easier for people.

<img width="797" alt="Screenshot 2023-08-14 at 14 53 29" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/8a747888-53d2-4007-b0a0-ba572cccfbad">

I've also made the hidden link a real link

<img width="820" alt="Screenshot 2023-08-14 at 14 57 15" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/a77f8790-158f-4d44-9a5e-968c19041562">

