### PR TITLE
Removed old guidance and updated a sentence in the new one

### DIFF
--- a/app/views/application-process.html
+++ b/app/views/application-process.html
@@ -24,44 +24,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <!--
-    <h1 class="govuk-heading-l">The application process for courses starting in September 2023</h1>
-
-      <p class="govuk-body">For courses starting in September 2023, you can start applying a year before they start in October 2022.</p>
-
-      <p class="govuk-body">Most teacher training courses are one year and start in September when the academic year in England starts. Part time courses are usually 2 years.</p>
-      <br>
-        <table class="govuk-table">
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header">Date and time</th>
-              <th scope="col" class="govuk-table__header">What happens</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            <tr class="govuk-table__row">
-             <td class="govuk-table__cell">4&nbsp;October&nbsp;2022 at 9am</td>
-              <td class="govuk-table__cell">Start <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses" class="govuk-link">finding postgraduate teacher training courses</a> you might want to apply to.</td>
-            </tr>
-            <tr class="govuk-table__row">
-             <td class="govuk-table__cell">11&nbsp;October&nbsp;2022 at 9am</td>
-              <td class="govuk-table__cell">Start applying for courses. You can apply to 4 courses at a time. Courses can fill up quickly, so you should apply as soon as you can.<br><br>You should make sure each course you choose is offered by a different training provider so you can have more chance of success.<br><br>Training providers will have 40 working days to decide to offer you a place on a course. Holiday periods in England over December and March or April are not included in the 40 working days. Each course you apply to will show the date for when providers need to respond by.<br><br>If training providers do not respond in time, your application will be unsuccessful.<br><br>You can apply to 4 courses again if all your applications are unsuccessful.<br><br>You’ll have 10 working days to respond to any offers you receive. If you do not respond, the offer will be automatically declined.</td>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">1 July 2023</td>
-              <td class="govuk-table__cell">The time training providers have to make a decision about your application is reduced from 40 working days to 20 working days.</td>
-            </tr>
-              <tr class="govuk-table__row">
-              <td class="govuk-table__cell">5 September 2023 at 6pm</td>
-              <td class="govuk-table__cell">If you’ve not already applied for teacher training, you will not be able to apply after 5 September 2023.<br><br> If you’ve already applied, but your applications were unsuccessful, you can continue to apply for courses until 19 September 2023 at 6pm.</td>
-            </tr>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">27&nbsp;September&nbsp;2023 at 11:59pm</td>
-              <td class="govuk-table__cell">The last day for training providers to make a decision on all applications for courses starting in September 2023.</td>
-            </tr>
-          </tbody>
-        </table>
-
-    -->
 
     <h1 class="govuk-heading-l">The application process for courses starting in September 2024</h1>
 
@@ -84,7 +46,7 @@
             </tr>
             <tr class="govuk-table__row">
              <td class="govuk-table__cell">10&nbsp;October&nbsp;2023 at 9am</td>
-              <td class="govuk-table__cell">Start applying to courses. You can apply to 4 courses offered by 4 different training providers. Courses can fill up quickly, so you should apply as soon as you can.<br><br>You can withdraw an application at any time and apply to a different course if you want to.<br><br>Training providers will have a month to look at your application and decide to offer you a place on a course. 
+              <td class="govuk-table__cell">Start applying to courses. You can apply to 4 courses, they can fill up quickly so you should apply as soon as you can.<br><br>You can withdraw an application at any time and apply to a different course if you want to.<br><br>Training providers will have a month to look at your application and decide to offer you a place on a course. 
               <br><br>If training providers do not respond in a month, you'll be able to apply to another course while you wait for a response. We'll tell you if the provider has not responded in time.<br><br>You’ll get an email if you receive an offer from a training provider.</td>
             </tr>
             <tr class="govuk-table__row">


### PR DESCRIPTION
The devs will be updating this page soon so I've removed the old guidance that was commented out in the code so there's no confusion.

I also edited a sentence that said you can apply for courses at 4 different training providers. This is incorrect, you can apply to the same provider if you want to.

**Before:**
<img width="608" alt="Screenshot 2023-08-31 at 10 26 09" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/a5905f4e-2100-466b-ad6a-4d5fcecea284">


**After:**
<img width="722" alt="Screenshot 2023-08-31 at 10 25 42" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/d142bc76-5a4a-484c-bc5c-32e4c98096d8">
