### PR TITLE
Added '30 working days' to application guidance for clarity

### DIFF
--- a/app/views/application-process.html
+++ b/app/views/application-process.html
@@ -46,8 +46,7 @@
             </tr>
             <tr class="govuk-table__row">
              <td class="govuk-table__cell">10&nbsp;October&nbsp;2023 at 9am</td>
-              <td class="govuk-table__cell">Start applying to courses. You can apply to 4 courses, they can fill up quickly so you should apply as soon as you can.<br><br>You can withdraw an application at any time and apply to a different course if you want to.<br><br>Training providers will have a month to look at your application and decide to offer you a place on a course. 
-              <br><br>If training providers do not respond in a month, you'll be able to apply to another course while you wait for a response. We'll tell you if the provider has not responded in time.<br><br>You’ll get an email if you receive an offer from a training provider.</td>
+              <td class="govuk-table__cell">Start applying to courses. You can apply to 4 courses, they can fill up quickly so you should apply as soon as you can.<br><br>You can withdraw an application at any time and apply to a different course if you want to.<br><br>If training providers do not respond to an application within 30 working days, you'll be able to apply to another course while you wait for a response. We'll tell you if the provider has not responded in time.<br><br>You’ll get an email if you receive an offer from a training provider.</td>
             </tr>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">17 September 2024 at 6pm</td>


### PR DESCRIPTION
I changed 'a month' to '30 working days' in the application process guidance, as that is more accurate. This came up in a conversation with GiT team so we should be consistent.

Before:

<img width="664" alt="Screenshot 2023-09-21 at 18 13 27" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/7e09538a-8b46-4dd1-9bcb-76372d36f1dc">

After:

<img width="593" alt="Screenshot 2023-09-21 at 18 13 52" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/729f26f0-0633-4ced-9dc4-0f36f217ceb5">

