### PR TITLE
Edited content to communicate cap of 15 unsuccessful applications

### DIFF
--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -40,7 +40,12 @@
     {% else %}
       <h1 class="govuk-heading-l">{{ title }}</h1>
       <p class="govuk-body">You cannot add any more applications.</p>
-      <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.</p>
+      <p class="govuk-body">You can add more applications if:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li class="govuk-body">one of your submitted applications becomes unsuccessful</li>
+        <li class="govuk-body">you withdraw or remove an application</li>
+      </ul>
+      <p class="govuk-body">Once you have a total of 15 unsuccessful or withdrawn applications, you will not be able to apply for any more courses until October 2024.</p>
       <p class="govuk-body"><a class="govuk-link" href="/application-process">Read about how the application process works.</a></p>
 
     {% endif %}


### PR DESCRIPTION
We've seen a lot of candidates withdraw applications quickly  and they are fast approaching 20 applications.

We decided to put a 'cap' of 15 unsuccessful applications to stop candidates using all their choices too quickly.

We show this content when a candidate had 3 submissions and it will replace the inset text on the Your applications tab.

Trello ticket: https://trello.com/c/Iz3bbY7a/759-edit-content-where-a-candidate-has-submitted-4-applications-already

**Content before:**
<img width="779" alt="Screenshot 2023-11-02 at 14 48 59" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/4e8bb0c2-25c4-4b9b-9484-e329afa7a3bd">

**Content after:**
<img width="779" alt="Screenshot 2023-11-02 at 14 34 56" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/aaeee9b5-91b9-4059-ad8a-e26f3d9a05cd">
