### PR TITLE
Removed 'Free of charge text"

### DIFF
--- a/app/views/details/index.html
+++ b/app/views/details/index.html
@@ -245,9 +245,8 @@
         <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="support-title">Get help</h2>
 
           <ul class="govuk-list govuk-!-font-size-16">
-            <li>Call 0800 389 2500 or chat online</li>
+            <li>Call 0800 389 2500 or <a href="https://getintoteaching.education.gov.uk/help-and-support">chat online</a></li>
             <li>Monday to Friday, 8:30am to 5:30pm (except public holidays)</li>
-            <li>Free of charge</li>
            </ul>
       </aside>
     </div>


### PR DESCRIPTION
The 'Free of charge" text on our Get help section on Apply is misleading for international candidates.

This PR removes that text and adds a link to the online chat on GiT.

### Before:
<img width="331" alt="Screenshot 2023-11-22 at 09 29 01" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/5bc17806-6d92-44aa-afae-652248359dd2">


### After:
<img width="378" alt="Screenshot 2023-11-22 at 09 29 07" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/df1fb11d-b309-4164-83a6-a25f3ee08d73">

Trello ticket: https://trello.com/c/ExTBmged/701-free-of-charge-phone-number-content-is-misleading
