### PR TITLE
Iterated content on 'Right to work or study page

### DIFF
--- a/app/views/details/personal-information/immigration.html
+++ b/app/views/details/personal-information/immigration.html
@@ -16,7 +16,7 @@
   <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">{{ title }}</h1>
 
-  <p class="govuk-body">You need a UK visa while you do your teacher training. You can use a visa which is due to expire before the end of your course, as long as you have the right to renew it.</p>
+  <p class="govuk-body">You need a visa or immigration status that allows you to work or study in the UK while you do your teacher training. You can use a visa which is due to expire before the end of your course, as long as you have the right to renew it.</p>
   <p class="govuk-body">If you do not have the right to work or study, you can apply for a visa when you’ve been accepted onto a course that sponsors visas.</p>
   <p class="govuk-body"><a href="https://www.gov.uk/check-uk-visa" class="govuk-link" rel="noreferrer noopener" target="_blank">Check if you need a UK visa</a>.</p>
   <!-- <p class="govuk-body">Use the ‘Visa sponsorship’ filter to <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/" class="govuk-link" target="_new">find courses that have visa sponsorship available</a>.</p> -->

--- a/app/views/details/personal-information/immigration.html
+++ b/app/views/details/personal-information/immigration.html
@@ -16,9 +16,9 @@
   <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">{{ title }}</h1>
 
-  <p class="govuk-body">You’ll need to have the right to work or study for the duration of your course. You can use a visa which is due to expire before the end of your course, as long as you have the right to renew it.</p>
-  <p class="govuk-body"><a href="https://www.gov.uk/check-uk-visa" class="govuk-link" rel="noreferrer noopener" target="_blank">Check your immigration status and whether you’ll need to apply for a visa</a>.</p>
+  <p class="govuk-body">You need a UK visa while you do your teacher training. You can use a visa which is due to expire before the end of your course, as long as you have the right to renew it.</p>
   <p class="govuk-body">If you do not have the right to work or study, you can apply for a visa when you’ve been accepted onto a course that sponsors visas.</p>
+  <p class="govuk-body"><a href="https://www.gov.uk/check-uk-visa" class="govuk-link" rel="noreferrer noopener" target="_blank">Check if you need a UK visa</a>.</p>
   <!-- <p class="govuk-body">Use the ‘Visa sponsorship’ filter to <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/" class="govuk-link" target="_new">find courses that have visa sponsorship available</a>.</p> -->
 <form action="{{ formaction }}" method="post">
   {{ govukRadios({


### PR DESCRIPTION
After testing the 'Right to work or study' page, there were recommendations to iterate the content.

### Before

<img width="548" alt="Screenshot 2023-12-08 at 15 27 08" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/62d78a94-08f3-4b15-93c3-89772047db92">

### After

<img width="711" alt="Screenshot 2023-12-12 at 09 24 25" src="https://github.com/DFE-Digital/apply-for-teacher-training-prototype/assets/68232608/c0ec0925-e5e6-47b0-9bc5-440db8189e74">

Changes include:
- Left H1 the same as people seemed to be familiar with this language/phrase
- Moved link to the bottom and shortened it so it doesn't stand out so much (the link text now also matches the H1 of the page it links to)
- Last paragraph is now moved up, as when people read this, they found it useful but the long link was distracting
- Changes the first sentence to not repeat the H1, instead it explains 'right to work or study' in plainer language (why didn't I think of this before!?)



