### PR TITLE
Confidential references

### DIFF
--- a/app/routes/reference.js
+++ b/app/routes/reference.js
@@ -9,7 +9,7 @@ module.exports = router => {
   })
 
   router.post('/reference/answer', (req, res) => {
-    const answer = req.body['reference-answer']
+    const answer = req.session.data['reference-answer']
 
     if (answer === 'Yes') {
       res.redirect('/reference/relationship')

--- a/app/views/_components/application-status/macro.njk
+++ b/app/views/_components/application-status/macro.njk
@@ -1,3 +1,3 @@
-{% macro appApplicationStatus(application, showDetails = true) %}
+{% macro appApplicationStatus(application, id, showDetails = true) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/app/views/applications/confirm.html
+++ b/app/views/applications/confirm.html
@@ -16,24 +16,20 @@
 
       <p class="govuk-body">When you accept your offer, we’ll send emails to the people you said could give you references.</p>
 
-      <div class="govuk-inset-text">
-      <p class="govuk-body">{{ data.applications[id].providerName }} said:</p>
-      <p class="govuk-body">You need 2 references to be accepted.</p>
-      </div>
+      <p class="govuk-body">Your referees can decide whether you will be able to view their reference.</p>
 
       <p class="govuk-body">You can change the reference details before you accept the offer.</p>
 
       {{ govukButton({
-        text: "Add details for another reference",
-        href: "/dashboard/references/add",
+        text: "Add another reference",
+        href: "/details/references/" + id + "/type",
         classes: "govuk-button--secondary"
       }) }}
 
+      {% include "_includes/review/references.html" %}
+
     </div>
   </div>
-
-
-  {% include "_includes/review/references.html" %}
 
   {% if numberOfOffersReceived > 1 %}
     <p class="govuk-body">Your other applications will be withdrawn and any upcoming interviews will be cancelled.</p>

--- a/app/views/applications/confirm.html
+++ b/app/views/applications/confirm.html
@@ -16,7 +16,8 @@
 
       <p class="govuk-body">When you accept your offer, we’ll send emails to the people you said could give you references.</p>
 
-      <p class="govuk-body">Your referees can decide whether you will be able to view their reference.</p>
+      <p class="govuk-body">They can decide whether you will be able to see their reference or if it is confidential.
+      </p>
 
       <p class="govuk-body">You can change the reference details before you accept the offer.</p>
 

--- a/app/views/applications/index.html
+++ b/app/views/applications/index.html
@@ -141,7 +141,7 @@
             text: "Status"
           },
           value: {
-            html: appApplicationStatus( application, true )
+            html: appApplicationStatus( application, id, true )
           }
         },
         {

--- a/app/views/applications/review-application.html
+++ b/app/views/applications/review-application.html
@@ -27,7 +27,7 @@
               text: "Status"
             },
             value: {
-              html: appApplicationStatus( application, false )
+              html: appApplicationStatus( application, id, false )
             }
           },
           {

--- a/app/views/details/references/index.html
+++ b/app/views/details/references/index.html
@@ -31,7 +31,14 @@
         <li>the headteacher if you’ve been working in a school</li>
       </ul>
 
-      <p class="govuk-body">They’ll be asked if they know any reason why you should not work with children.</p>
+      <p class="govuk-body">They’ll be asked:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>whether they know any reason why you should not work with children</li>
+        <li>to give factual information, for example about your role and responsibilities at work</li>
+      </ul>
+
+      <p class="govuk-body">Your referees can decide whether you will be able to view their reference.</p>
 
       <div class="govuk-body">
         {% if numberOfApplicationsLeft >= 4 %}
@@ -41,9 +48,7 @@
           href: "/details/references/add",
           classes: referencesButtonClass
         }) }}
-        {% else %}
-
-{% endif %}
+        {% endif %}
       </div>
     </div>
   </div>

--- a/app/views/details/references/index.html
+++ b/app/views/details/references/index.html
@@ -22,24 +22,24 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
 
-      <p class="govuk-body">You need to give the email address of 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
-
-      <p class="govuk-body">You should include:</p>
-
+      <p class="govuk-body">You need to give the email addresses of at least 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
+      <p class="govuk-body"><a href="https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-references">Find out more about providing references</a></p>
+      <p>When you are choosing references you should:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>an academic tutor if you graduated in the past 5 years or are still studying</li>
-        <li>the headteacher if you’ve been working in a school</li>
+        <li>select an academic reference (for example a tutor) if you graduated in the last 5 years, or if you are still studying</li>
+        <li>give the contact details of the headteacher if you’ve been working in a school</li>
+        <li>choose any combination of references if you graduated more than 5 years ago or do not work in a school</li>
       </ul>
 
       <p class="govuk-body">They’ll be asked:</p>
 
       <ul class="govuk-list govuk-list--bullet">
+        <li>to confirm how they know you</li>
         <li>whether they know any reason why you should not work with children</li>
-        <li>to give factual information, for example about your role and responsibilities at work</li>
+        <li>to give factual information, for example course or employment dates</li>
+        <li>whether they want you to be able to see their reference or if it is confidential.</li>
       </ul>
-
-      <p class="govuk-body">Your referees can decide whether you will be able to view their reference.</p>
-
+      <br>
       <div class="govuk-body">
         {% if numberOfApplicationsLeft >= 4 %}
         {% set referencesButtonClass = "govuk-button--secondary" if references | length > 1 else "" %}

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -97,6 +97,10 @@
         {
           href: "/admin/add-application",
           text: "Add application"
+        },
+        {
+          href: "/reference",
+          text: "Provide reference"
         }
       ]
     }

--- a/app/views/reference/index.html
+++ b/app/views/reference/index.html
@@ -21,9 +21,9 @@
 
       <p class="govuk-body">{{ candidate_name }} has accepted an offer from {{ provider_name }} for a place on a teacher training course. They’ve said that you can give them a reference.</p>
 
-      <p class="govuk-body">Your reference will not be sent to {{ candidate_name }}.</p>
+      <p class="govuk-body">You can choose whether {{ candidate_name }} should be able to view the reference or not.</p>
 
-      <form action="/reference/answer" method="post">
+      <form action="/reference/share" method="post">
         {{ govukRadios({
           fieldset: {
             legend: {

--- a/app/views/reference/index.html
+++ b/app/views/reference/index.html
@@ -21,7 +21,8 @@
 
       <p class="govuk-body">{{ candidate_name }} has accepted an offer from {{ provider_name }} for a place on a teacher training course. They’ve said that you can give them a reference.</p>
 
-      <p class="govuk-body">You can choose whether {{ candidate_name }} should be able to view the reference or not.</p>
+      <p class="govuk-body">You can choose whether {{ candidate_name }} should be able to see the contents of your reference or if it should be confidential.
+        .</p>
 
       <form action="/reference/share" method="post">
         {{ govukRadios({

--- a/app/views/reference/review.html
+++ b/app/views/reference/review.html
@@ -85,6 +85,20 @@
               visuallyHiddenText: "reference"
             }]
           }
+        }, {
+          key: {
+            text: "Can your reference be shared with " + candidate_name + "?"
+          },
+          value: {
+            html: (data['reference-share'])
+          },
+          actions: {
+            items: [{
+              href: "/reference/share?referrer=/reference/review",
+              text: "Change",
+              visuallyHiddenText: "reference"
+            }]
+          }
         }]
       }) }}
 

--- a/app/views/reference/share.html
+++ b/app/views/reference/share.html
@@ -29,7 +29,7 @@
             checked: (data["reference-share"] == "Yes")
           }, {
             value: "No",
-            text: "No",
+            text: "No, it should be treated as confidential",
             checked: (data["reference-share"] == "No")
           }]
         }) }}

--- a/app/views/reference/share.html
+++ b/app/views/reference/share.html
@@ -1,0 +1,43 @@
+{% extends "layouts/main.html" %}
+
+{% set candidate_name = "Jane Doe" %}
+{% set provider_name = "West Lancashire SCITT" %}
+{% set title = "A reference for " + candidate_name + "" %}
+{% set hasAccountLinks = false %}
+
+{% block beforeContent %}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">Can your reference be shared with {{ candidate_name }}?</h1>
+
+      <form action="/reference/answer" method="post">
+        {{ govukRadios({
+          idPrefix: "reference-share",
+          name: "reference-share",
+          items: [{
+            value: "Yes",
+            text: "Yes, if they request it",
+            checked: (data["reference-share"] == "Yes")
+          }, {
+            value: "No",
+            text: "No",
+            checked: (data["reference-share"] == "No")
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Giving referees the ability to state whether a reference is confidential or not.

[Ticket](https://trello.com/c/RAFpL0Gm/171-references-content-to-clarify-confidentiality-choice)

[Content source](https://educationgovuk.sharepoint.com.mcas.ms/:w:/r/sites/TeacherServices/_layouts/15/Doc.aspx?sourcedoc=%7B8664D7BA-647C-4615-88CB-23C9B7430B32%7D&file=Degree%20relevance%20matching%20-%20Rules.docx&action=default&mobileredirect=true)

