### PR TITLE
Adding a flight check for applicants supplying a personal email address for a referee

### DIFF
--- a/app/routes/applications.js
+++ b/app/routes/applications.js
@@ -276,13 +276,11 @@ module.exports = router => {
     const submitNowPost = req.body.submitNowPost
 
     const references = (req.session.data.references ? Object.values(req.session.data.references) : [])
-    let referencesPersonalEmail = false
 
     // Request all the references
     for (const reference of references) {
-
-      if ( ( reference.email.indexOf('gmail') > 1 || reference.email.indexOf('hotmail') > 1 ) && !( req.session.data.references[id].type == 'character') ) {
-        referencesPersonalEmail = true
+      if ( ( reference.email.indexOf('gmail') > 1 || reference.email.indexOf('hotmail') > 1 ) && !( reference.type == 'character') ) {
+        req.session.data.referencesPersonalEmail = true
         break
       }
     }
@@ -294,7 +292,7 @@ module.exports = router => {
     else if (submitNow == 'yes' && degree.G3CL4.grade == "Third-class honours") {
       res.redirect('/applications/'+ id + '/interruption-module')
     }
-    else if (submitNow == 'yes' && referencesPersonalEmail ) {
+    else if (submitNow == 'yes' && req.session.data.referencesPersonalEmail ) {
       res.redirect('/applications/'+ id + '/interruption-module')
     }
     else if (submitNowPost == 'yes') {

--- a/app/routes/applications.js
+++ b/app/routes/applications.js
@@ -275,11 +275,26 @@ module.exports = router => {
     const submitNow = req.body.submitNow
     const submitNowPost = req.body.submitNowPost
 
+    const references = (req.session.data.references ? Object.values(req.session.data.references) : [])
+    let referencesPersonalEmail = false
+
+    // Request all the references
+    for (const reference of references) {
+
+      if ( ( reference.email.indexOf('gmail') > 1 || reference.email.indexOf('hotmail') > 1 ) && !( req.session.data.references[id].type == 'character') ) {
+        referencesPersonalEmail = true
+        break
+      }
+    }
+
 // interruption module for personal
     if (submitNow == 'yes' && personalstatementl < 500) {
       res.redirect('/applications/'+ id + '/interruption-module')
     }
     else if (submitNow == 'yes' && degree.G3CL4.grade == "Third-class honours") {
+      res.redirect('/applications/'+ id + '/interruption-module')
+    }
+    else if (submitNow == 'yes' && referencesPersonalEmail ) {
       res.redirect('/applications/'+ id + '/interruption-module')
     }
     else if (submitNowPost == 'yes') {

--- a/app/routes/details/references.js
+++ b/app/routes/details/references.js
@@ -11,6 +11,22 @@ module.exports = router => {
     res.redirect(`/details/references/${id}/type`)
   })
 
+
+  router.post('/details/references/:id/check-email', (req, res) => {
+    const id = req.params.id;
+    const isPersonalEmail = ( req.session.data.references[id].email.indexOf('gmail') > 1 || req.session.data.references[id].email.indexOf('hotmail') > 1 )
+
+    if (isPersonalEmail && !( req.session.data.references[id].type == 'character' ) ) {
+      res.redirect(`/details/references/${id}/email-warning`)
+    } else {
+      res.redirect(`/details/references/${id}/relationship`)
+    }
+  })
+
+  router.get('/details/references/:id/email-warning', (req, res) => {
+    res.render('/details/references/email-warning', { id: req.params.id } )
+  })
+
   // References review page
   router.get('/details/references', (req, res) => {
 

--- a/app/views/applications/interruption-module.html
+++ b/app/views/applications/interruption-module.html
@@ -15,8 +15,15 @@
     <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
     <div class="app-grid-column--grey">
-          <h3 class="govuk-heading-l">Give your application the best chance of success</h3>
-  {% if data.personalStatement.length < 500 %}
+      <h3 class="govuk-heading-l">Give your application the best chance of success</h3>
+
+  {% if data.referencesPersonalEmail %}
+        <p class="govuk-body">At least one of your references looks like it is using a personal email address</p>
+        <p class="govuk-body">Many providers will not accept references from a personal email address (such as gmail.com).</p>
+        <p class="govuk-body">You should ask your referees if they have work email addresses you can use instead and update your application.</p>
+        <p class="govuk-body">If you cannot get any other email addresses you can still submit this application. You should explain why you are using a personal email address when you say how you know each person.</p>
+
+  {% elif data.personalStatement.length < 500 %}
         {#------ Personal Statement ------#}
         <p class="govuk-body">Your personal statement is {{data.personalStatement.length}} words.</p>
         <p class="govuk-body">90% of successful candidates write about 500 words or more for their personal statement.</p>
@@ -45,7 +52,10 @@
     text: "Submit application",
     classes: "govuk-button--inverse"
   }) }}
-  {% if data.personalStatement.length < 500 %}
+
+  {% if data.referencesPersonalEmail %}
+  <a class="govuk-link" href="/details/personal-statement">Update your references</a>
+  {% elif data.personalStatement.length < 500 %}
   <a class="govuk-link" href="/details/personal-statement">Edit your personal statement</a>
  {% elif degree.G3CL4.grade == "Third-class honours"%}
    <a class="govuk-link" href="/applications">Save as a draft</a>
@@ -55,22 +65,29 @@
   {% endif %}
   </form> #}
   <form action="/applications/{{ id }}/review-and-submit" method="post">
-   <p class="govuk-body govuk-fieldset__legend--s">Would you like to edit your personal statement before submitting your application?</p>
-     {% if data.personalStatement.length < 500 %}
-  {{ govukButton({
-    text: "Edit your personal statement",
-    href: "/details/personal-statement"
-  }) }}
- {% elif degree.G3CL4.grade == "Third-class honours"%}
+
+   {% if data.referencesPersonalEmail %}
    {{ govukButton({
-    text: "Save as a draft",
-    href: "/applications"
-  }) }}
-  {% else%}
-     {{ govukButton({
-    text: "Add references",
-    href: "/details/references"
-  }) }}
+     text: "Update your references",
+     href: "/details/references"
+   }) }}
+
+   {% elif data.personalStatement.length < 500 %}
+   <p class="govuk-body govuk-fieldset__legend--s">Would you like to edit your personal statement before submitting your application?</p>
+    {{ govukButton({
+      text: "Edit your personal statement",
+      href: "/details/personal-statement"
+    }) }}
+  {% elif degree.G3CL4.grade == "Third-class honours"%}
+    {{ govukButton({
+      text: "Save as a draft",
+      href: "/applications"
+    }) }}
+  {% else %}
+      {{ govukButton({
+      text: "Add references",
+      href: "/details/references"
+    }) }}
   {% endif %}
     <a class="govuk-link" href="/applications/{{ id }}/review-and-submit">Continue without editing</a>
   </form>

--- a/app/views/applications/interruption-module.html
+++ b/app/views/applications/interruption-module.html
@@ -20,8 +20,8 @@
   {% if data.referencesPersonalEmail %}
         <p class="govuk-body">At least one of your references looks like it is using a personal email address</p>
         <p class="govuk-body">Many providers will not accept references from a personal email address (such as gmail.com).</p>
-        <p class="govuk-body">You should ask your referees if they have work email addresses you can use instead and update your application.</p>
-        <p class="govuk-body">If you cannot get any other email addresses you can still submit this application. You should explain why you are using a personal email address when you say how you know each person.</p>
+        <p class="govuk-body">You should ask your references if they have a work email address you can use instead and update your application.</p>
+        <p class="govuk-body">If you cannot get another email address for the reference you can still submit this application. You should explain why you are using a personal email address when you say how you know the person.</p>
 
   {% elif data.personalStatement.length < 500 %}
         {#------ Personal Statement ------#}

--- a/app/views/details/references/email-warning.html
+++ b/app/views/details/references/email-warning.html
@@ -20,7 +20,7 @@
               <p class="govuk-body">Many providers will not accept references from a personal email address (such as gmail.com).</p>
               <p class="govuk-body">You should ask {{ data.references[id].name or 'Janet Harper' }} if they have a work email address you can use instead and update your application.</p>
               <p class="govuk-body">If you cannot get another email address for this reference you can still submit this application. You should explain why you are using a personal email address when you say how you know this person.</p>
-              <p class="govuk-body"><a href="/details/references/{{ id }}/email">Go back and change the email address used</a></p>
+              <p class="govuk-body"><a href="/details/references/{{ id }}/email">Go back and change the email address</a></p>
           </div>
           </div>
         </div>

--- a/app/views/details/references/email-warning.html
+++ b/app/views/details/references/email-warning.html
@@ -1,0 +1,31 @@
+{% extends "layouts/main.html" %}
+
+{% set primaryNavId = "details" %}
+
+{% set title = "Providers may not accept a personal email address" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "/details/references/" + id + "/email/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+      <form action="/details/references/{{ id }}/relationship" method="post">
+
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-three-quarters">
+          <div class="app-grid-column--grey">
+              <h3 class="govuk-heading-l">Providers may not accept references from a personal email address</h3>
+              <p class="govuk-body">You entered <strong>{{ data.references[id].email}}</strong> as {{ data.references[id].name}}'s email address.</p>
+              <p class="govuk-body">You should ask {{ data.references[id].name}} if they have a work email address you can use instead.</p>
+              <p class="govuk-body"><a href="/details/references/{{ id }}/email">Go back and change the email address used</a></p>
+          </div>
+          </div>
+        </div>
+
+        {{ govukButton({
+          text: "Save changes" if referrer else "Save and continue"
+        }) }}
+      </form>
+{% endblock %}

--- a/app/views/details/references/email-warning.html
+++ b/app/views/details/references/email-warning.html
@@ -16,9 +16,10 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">
           <div class="app-grid-column--grey">
-              <h3 class="govuk-heading-l">Providers may not accept references from a personal email address</h3>
-              <p class="govuk-body">You entered <strong>{{ data.references[id].email}}</strong> as {{ data.references[id].name}}'s email address.</p>
-              <p class="govuk-body">You should ask {{ data.references[id].name}} if they have a work email address you can use instead.</p>
+              <h3 class="govuk-heading-l">{{ data.references[id].email or 'janet@gmail.com' }} looks like a personal email address</h3>
+              <p class="govuk-body">Many providers will not accept references from a personal email address (such as gmail.com).</p>
+              <p class="govuk-body">You should ask {{ data.references[id].name or 'Janet Harper' }} if they have a work email address you can use instead and update your application.</p>
+              <p class="govuk-body">If you cannot get another email address for this reference you can still submit this application. You should explain why you are using a personal email address when you say how you know this person.</p>
               <p class="govuk-body"><a href="/details/references/{{ id }}/email">Go back and change the email address used</a></p>
           </div>
           </div>

--- a/app/views/details/references/email.html
+++ b/app/views/details/references/email.html
@@ -23,7 +23,7 @@
             isPageHeading: true
           },
           hint: {
-            text: "Give their work email address if they have one."
+            text: "Enter their professional email address if you know it. Many providers will not accept references that come from a personal email address."
           },
           type: "email",
           autocomplete: "false",

--- a/app/views/details/references/email.html
+++ b/app/views/details/references/email.html
@@ -13,7 +13,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="/details/references/{{ id }}/relationship" method="post" novalidate="true">
+      <form action="/details/references/{{ id }}/check-email" method="post" novalidate="true">
         {{ govukInput({
           name: "references[" + id + "][email]",
           value: data.references[id].email,

--- a/app/views/details/references/relationship.html
+++ b/app/views/details/references/relationship.html
@@ -38,7 +38,7 @@
           threshold: 85
         }) }}
 
-        <p class="govuk-body">We’ll show your answer to {{referee.name}} and ask them whether it’s correct.</p>
+        <p class="govuk-body">We’ll show your answer to {{ data.references[id].name}} and ask them whether it’s correct.</p>
 
         {{ govukButton({
           text: "Save changes" if referrer else "Save and continue"


### PR DESCRIPTION
### Adding a flight check for applicants supplying a personal email address for a referee

[Ticket with background info](https://trello.com/c/Janox9Gc)

**Updated hint text when entering email address:**

<img width="731" alt="image" src="https://github.com/user-attachments/assets/eed5c1b0-85a6-46ae-951e-0fbda4c3c3de">

**Flight check when entering a personal email address for a reference:**

<img width="816" alt="image" src="https://github.com/user-attachments/assets/280f770a-b88c-47e8-a980-b9ad98899f59">

**Flight check when trying to submit application which contains a personal email address for a reference:**

<img width="755" alt="image" src="https://github.com/user-attachments/assets/a1991e2d-4294-444f-911d-eaa00350e257">
